### PR TITLE
Get cross compiler prefix

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -367,6 +367,7 @@ def cmd_build(cfg):
 
     krelease = builder.getrelease()
     kernel_arch = builder.build_arch
+    cross_compiler_prefix = builder.cross_compiler_prefix
     make_opts = ' '.join(builder.make_argv_base
                          + builder.targz_pkg_argv
                          + builder.extra_make_args)
@@ -374,6 +375,7 @@ def cmd_build(cfg):
     save_state(cfg, {'buildconf': tconfig,
                      'krelease': krelease,
                      'kernel_arch': kernel_arch,
+                     'cross_compiler_prefix': cross_compiler_prefix,
                      'make_opts': make_opts})
 
     report_string = '{} ({{{}}})\n{}\n    {}'.format(

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -152,6 +152,18 @@ class KernelBuilder(object):
 
         return platform.machine()
 
+    def __get_cross_compiler_prefix(self):
+        """
+        Determine the cross compiler prefix for the kernel build.
+
+        Returns:
+            The cross compiler prefix, if defined in the environment.
+        """
+        if 'CROSS_COMPILE' in os.environ:
+            return os.environ['CROSS_COMPILE']
+
+        return None
+
     def get_cfgpath(self):
         return join_with_slash(self.source_dir, ".config")
 

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -41,6 +41,7 @@ class KernelBuilder(object):
         self.make_argv_base = ["make", "-C", self.source_dir]
         self.enable_debuginfo = enable_debuginfo
         self.build_arch = self.__get_build_arch()
+        self.cross_compiler_prefix = self.__get_cross_compiler_prefix()
         self.rh_configs_glob = rh_configs_glob
         self.localversion = localversion
 

--- a/skt/templates/partials/build_details.j2
+++ b/skt/templates/partials/build_details.j2
@@ -4,7 +4,8 @@
 We compiled the kernel for {{ jobs_run }} {{ arch_plural }}:
 
   {% for job in report_jobs %}
-  {{ job.kernel_arch }}:
+  {% set kernel_arch = job.cross_compiler_prefix.split('-')[0] if job.cross_compiler_prefix else job.kernel_arch %}
+  {{ kernel_arch }}:
     make options: {{ job.make_opts }}
     configuration: {{ job.cfgurl }}
 

--- a/skt/templates/partials/build_failure.j2
+++ b/skt/templates/partials/build_failure.j2
@@ -2,10 +2,11 @@ We attempted to compile the kernel for multiple architectures, but the compile
 failed on one or more architectures:
 
 {% for job in report_jobs %}
+  {% set kernel_arch = job.cross_compiler_prefix.split('-')[0] if job.cross_compiler_prefix else job.kernel_arch %}
   {% if job.buildlog %}
-  {{ (job.kernel_arch + ":").ljust(8) }} FAILED (build log attached: {{ job.buildlog }})
+  {{ (kernel_arch + ":").ljust(8) }} FAILED (build log attached: {{ job.buildlog }})
   {% else %}
-  {{ (job.kernel_arch + ":").ljust(8) }} PASSED
+  {{ (kernel_arch + ":").ljust(8) }} PASSED
   {% endif %}
 {% endfor %}
 

--- a/skt/templates/partials/test_failure.j2
+++ b/skt/templates/partials/test_failure.j2
@@ -1,11 +1,12 @@
 One or more hardware tests failed:
 
 {% for job in report_jobs %}
+  {% set kernel_arch = job.cross_compiler_prefix.split('-')[0] if job.cross_compiler_prefix else job.kernel_arch %}
   {# If the job has no test results, then it passed. #}
   {% if job.test_results %}
-  {{ job.kernel_arch }}: FAILED
+  {{ kernel_arch }}: FAILED
   {% else %}
-  {{ job.kernel_arch }}: PASSED
+  {{ kernel_arch }}: PASSED
   {% endif %}
   {# Loop over the failed tasks and display them with their logs. #}
   {% for test_result in job.test_results %}

--- a/tests/test_kernelbuilder.py
+++ b/tests/test_kernelbuilder.py
@@ -96,6 +96,18 @@ class KBuilderTest(unittest.TestCase):
 
         self.assertEqual('s390x', result)
 
+    def test_get_cross_compiler_prefix(self):
+        """
+        Ensure __get_cross_compiler_prefix() returns the CROSS_COMPILE
+        environment variable.
+        """
+        # pylint: disable=W0212,E1101
+        os.environ['CROSS_COMPILE'] = 'powerpc64-linux-gnu-'
+        build = self.kbuilder
+        result = build._KernelBuilder__get_cross_compiler_prefix()
+
+        self.assertEqual('powerpc64-linux-gnu-', result)
+
     def test_mktgz_timeout(self):
         """Ensure the build fails properly when it exceeds the timeout."""
         self.m_popen.poll = Mock(side_effect=[None, None, -15])


### PR DESCRIPTION
Use cross compiler prefix in report if available

The cross compiler prefix is usually more descriptive than the kernel
arch used to build the kernel. As an example, 'powerpc' appears for both
big and little endian but the compiler names are different.

This patch uses the cross compiler prefix in the report if it is
available.

This is a remake of #380.