### PR TITLE
templates: Fix letter order in the logo

### DIFF
--- a/skt/templates/base.j2
+++ b/skt/templates/base.j2
@@ -58,9 +58,9 @@ Please reply to this email if you have any questions about the tests that we
 ran or if you have any suggestions on how to make future tests more effective.
 
         ,-.   ,-.
-       ( C ) ( I )  Continuous
+       ( C ) ( K )  Continuous
         `-',-.`-'   Kernel
-          ( K )     Integration
+          ( I )     Integration
            `-'
 ______________________________________________________________________________
 {# If we merged anything, we need to explain what we did and in what order. #}


### PR DESCRIPTION
Make the ASCII-art logo spell the project name in the left-right,
top-bottom order, so it reads "CKI", rather than "CIK".