### PR TITLE
Clarify 'hardware tests' in report

### DIFF
--- a/skt/templates/base.j2
+++ b/skt/templates/base.j2
@@ -22,7 +22,7 @@ The results of these automated tests are provided below.
     Overall result: FAILED (see details below)
        Patch merge: OK
            Compile: OK
-     Hardware test: FAILED
+      Kernel tests: FAILED
 {% elif multireport_failed.name == 'BUILD' %}
     Overall result: FAILED  (see details below)
        Patch merge: OK
@@ -34,7 +34,7 @@ The results of these automated tests are provided below.
     Overall result: PASSED
        Patch merge: OK
            Compile: OK
-     Hardware test: OK
+      Kernel tests: OK
 {% endif %}
 
 {% if multireport_failed.name != 'PASS' %}

--- a/skt/templates/partials/test_details.j2
+++ b/skt/templates/partials/test_details.j2
@@ -1,5 +1,5 @@
 
-We booted the compiled kernel and ran the following hardware tests:
+We booted each kernel and ran the following tests:
 
 {% for job in report_jobs %}
   {{ job.kernel_arch }}:

--- a/skt/templates/partials/test_failure.j2
+++ b/skt/templates/partials/test_failure.j2
@@ -1,4 +1,4 @@
-One or more hardware tests failed:
+One or more kernel tests failed:
 
 {% for job in report_jobs %}
   {% set kernel_arch = job.cross_compiler_prefix.split('-')[0] if job.cross_compiler_prefix else job.kernel_arch %}

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -294,7 +294,7 @@ class TestStdioReporter(unittest.TestCase):
         required_strings = [
             'Subject: FAIL: Test report for kernel 3.10.0 (kernel)',
             'Overall result: FAILED',
-            'Hardware test: FAILED',
+            'Kernel tests: FAILED',
             self.basecfg['basehead'],
             self.basecfg['baserepo'],
         ]
@@ -547,7 +547,7 @@ class TestStdioReporter(unittest.TestCase):
         required_strings = [
             'FAIL: Test report for kernel 3.10.0 (kernel)',
             'Overall result: FAILED',
-            'Hardware test: FAILED',
+            'Kernel tests: FAILED',
             self.basecfg['basehead'],
             self.basecfg['baserepo'],
         ]
@@ -605,7 +605,7 @@ class TestStdioReporter(unittest.TestCase):
         required_strings = [
             'FAIL: Test report for kernel 3.10.0 (kernel)',
             'Overall result: FAILED',
-            'Hardware test: FAILED',
+            'Kernel tests: FAILED',
             self.basecfg['basehead'],
             self.basecfg['baserepo'],
         ]


### PR DESCRIPTION
The wording for the testing details is a little confusing. We're testing
the kernel on physical hardware, not performing testing of the hardware
itself. This patch clarifies the wording.

Signed-off-by: Major Hayden <major@redhat.com>