### PR TITLE
reporter: Use empty list as CC and BCC defaults

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -505,8 +505,9 @@ class MailReporter(Reporter):
         # Get all of the required fields to send an email
         self.mailfrom = cfg['reporter']['mail_from']
         self.mailto = [to.strip() for to in cfg['reporter']['mail_to']]
-        self.mailcc = [cc.strip() for cc in cfg['reporter']['mail_cc']]
-        self.mailbcc = [bcc.strip() for bcc in cfg['reporter']['mail_bcc']]
+        self.mailcc = [cc.strip() for cc in cfg['reporter']['mail_cc'] or []]
+        self.mailbcc = [bcc.strip()
+                        for bcc in cfg['reporter']['mail_bcc'] or []]
         self.headers = [headers.strip() for headers in
                         cfg['reporter']['mail_header']]
         self.subject = cfg['reporter']['mail_subject']


### PR DESCRIPTION
Use empty lists for CC and BCC address lists when they're unspecified,
instead of throwing an exception like this one:
```
Traceback (most recent call last):
  File "./bin/skt", line 11, in <module>
    sys.exit(main())
  File "./lib/python2.7/site-packages/skt/executable.py", line 1098, in main
    args.func(cfg)
  File "./lib/python2.7/site-packages/skt/executable.py", line 489, in cmd_report
    reporter = reporter_class(cfg)
  File "./lib/python2.7/site-packages/skt/reporter.py", line 508, in __init__
    self.mailcc = [cc.strip() for cc in cfg['reporter']['mail_cc']]
TypeError: 'NoneType' object is not iterable
```