### PR TITLE
Raise an exception if the replacement value is not a string

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -104,6 +104,10 @@ class BeakerRunner(Runner):
             replacements:   A dictionary of placeholder strings with "##"
                             around them, and their replacements.
 
+        Raises:
+            ValueError if the placeholder would be replaced by a non-string
+                       object.
+
         Returns:
             The job XML text with template replacements applied.
         """
@@ -111,9 +115,15 @@ class BeakerRunner(Runner):
         with open(self.template, 'r') as fileh:
             for line in fileh:
                 for match in re.finditer(r"##(\w+)##", line):
-                    if match.group(1) in replacements:
+                    to_replace = match.group(1)
+                    if to_replace in replacements:
+                        if not isinstance(replacements[to_replace], str):
+                            raise ValueError('XML replace: string expected but'
+                                             ' {} is {}'.format(
+                                                 to_replace,
+                                                 replacements[to_replace]))
                         line = line.replace(match.group(0),
-                                            replacements[match.group(1)])
+                                            replacements[to_replace])
 
                 xml += line
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -63,6 +63,15 @@ class TestRunner(unittest.TestCase):
         result = self.myrunner._BeakerRunner__getxml({})
         self.assertEqual(result, self.test_xml)
 
+    def test_getxml_invalid_replace(self):
+        """
+        Ensure BeakerRunner.__getxml() raises ValueError if the replacement is
+        not a string.
+        """
+        # pylint: disable=W0212,E1101
+        with self.assertRaises(ValueError):
+            self.myrunner._BeakerRunner__getxml({"KVER": None})
+
     def test_getxml_replace(self):
         """Ensure BeakerRunner.__getxml() returns xml with replacements."""
         # pylint: disable=W0212,E1101


### PR DESCRIPTION
It is expected that the placeholders in the Beaker XMLs are replaced by
the values grabbed from the state file. However, because of a bug in skt
or manual testing process, the state file might not contain them. Trying
to use `None` as the value results in a cryptic `expected a character
buffer object` error. We need to use a cleaner message to indicate
what's wrong.

OTOH, the values typically grabbed from the state file might not be
needed because the XML already contains the right strings. Therefore, we
shouldn't raise the exception if the values in the state file are not
present, but only if we try to actually replace a placeholder with the
nonexistent value.

Fixes: #388

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>