### PR TITLE
Don't cause exception if the config fails to build

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -363,18 +363,22 @@ def cmd_build(cfg):
         save_state(cfg, {'tarpkg': ttgz})
 
     tconfig = '%s.config' % cfg.get('buildhead')
-    shutil.copyfile(builder.get_cfgpath(), tconfig)
+    try:
+        shutil.copyfile(builder.get_cfgpath(), tconfig)
+        krelease = builder.getrelease()
+        save_state(cfg, {'buildconf': tconfig,
+                         'krelease': krelease})
+    except IOError:  # Kernel config failed to build
+        tconfig = ''
+        logging.error('No config file to copy found!')
 
-    krelease = builder.getrelease()
     kernel_arch = builder.build_arch
     cross_compiler_prefix = builder.cross_compiler_prefix
     make_opts = ' '.join(builder.make_argv_base
                          + builder.targz_pkg_argv
                          + builder.extra_make_args)
 
-    save_state(cfg, {'buildconf': tconfig,
-                     'krelease': krelease,
-                     'kernel_arch': kernel_arch,
+    save_state(cfg, {'kernel_arch': kernel_arch,
                      'cross_compiler_prefix': cross_compiler_prefix,
                      'make_opts': make_opts})
 


### PR DESCRIPTION
While failing to build kernel config sets the correct buildlog and
return code, in the follow-up code we are trying to copy a nonexistent
config file. This causes an exception to be raised, hiding the original
build failure behind what is considered an infrastructure problem.

We can solve this by wrapping the copying into a try-except block, but
we also need to include the `getrelease()` call in it -- this function
calls config generation if it didn't succeed before and it would fail
again. By including it in the block, we make sure the exception raised
by the copying is caught and the `getrelease()` is not called.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>