### PR TITLE
Always cancel beaker jobs on exit

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -16,12 +16,14 @@ from __future__ import print_function
 import ConfigParser
 import argparse
 import ast
+import atexit
 import datetime
 import importlib
 import json
 import logging
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -443,6 +445,10 @@ def cmd_run(cfg):
     run_report_path = join_with_slash(cfg.get('output_dir'), 'run.report')
 
     runner = skt.runner.getrunner(*cfg.get('runner'))
+
+    atexit.register(runner.cleanup_handler)
+    signal.signal(signal.SIGINT, runner.signal_handler)
+    signal.signal(signal.SIGTERM, runner.signal_handler)
     retcode, report_string = runner.run(cfg.get('buildurl'),
                                         cfg.get('max_aborted_count'),
                                         cfg.get('krelease'),


### PR DESCRIPTION
This implements FASTMOVING-357.

At the moment, if skt is terminated, it doesn't always cancel its Beaker
jobs.

This patch wraps runner.run() with cleanup handler using atexit and
signal. When skt terminates, runner's cancel_pending_jobs() is called.

Signed-off-by: Jakub Racek <jracek@redhat.com>