### PR TITLE
runner: blacklisting: fix adding to hostrequires

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -210,10 +210,11 @@ class BeakerRunner(Runner):
             host_requires.append(and_node)
 
         for disabled in self.blacklisted:
-            hostname = etree.Element('hostname')
+            hostname = etree.SubElement(and_node, 'hostname')
             hostname.set('op', '!=')
             hostname.set('value', disabled)
-            and_node.append(hostname)
+
+        host_requires.append(and_node)
 
         return host_requires
 


### PR DESCRIPTION
The tests I wrote revealed that appending a new node to blacklist a
hostname to hostrequires doesn't work. This patch fixes it.

Signed-off-by: Jakub Racek <jracek@redhat.com>