### PR TITLE
Add tests for skt/runner.py:run

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -287,7 +287,7 @@ class BeakerRunner(Runner):
 
             for recipe_set_id in self.watchlist.copy():
                 root = self.getresultstree(recipe_set_id)
-                recipes = root.findall('recipe')
+                recipes = root.findall('.//recipe')
 
                 for recipe in recipes:
                     result = recipe.attrib.get('result')

--- a/tests/assets/beaker_aborted_some.xml
+++ b/tests/assets/beaker_aborted_some.xml
@@ -1,0 +1,62 @@
+<job id="0001">
+  <whiteboard>
+    skt 4.17.0-rc1+ 1234567890.tar.gz [noavc] [noselinux]
+  </whiteboard>
+  <recipeSet>
+    <recipe result='Warn' status='Aborted' id="123">
+      <logs>
+        <log name='console.log' href="http://example.com/">
+          TEST RESULT
+        </log>
+      </logs>
+      <task name='/test/misc/machineinfo'>
+        <logs>
+          <log name='machinedesc.log' href="http://example.com/machinedesc.log">
+          </log>
+          <log name='lshw.log' href="http://example.com/lshw.log">
+          </log>
+        </logs>
+      </task>
+      <task name='/distribution/install' result='Fail'>
+      </task>
+    </recipe>
+  </recipeSet>
+  <recipeSet>
+    <recipe result='Pass' status='Completed' id="456456">
+      <logs>
+        <log name='console.log' href="http://example.com/">
+          TEST RESULT
+        </log>
+      </logs>
+      <task name='/test/misc/machineinfo'>
+        <logs>
+          <log name='machinedesc.log' href="http://example.com/machinedesc.log">
+          </log>
+          <log name='lshw.log' href="http://example.com/lshw.log">
+          </log>
+        </logs>
+      </task>
+      <task name='/distribution/install' result='Fail'>
+      </task>
+    </recipe>
+  </recipeSet>
+    <recipeSet>
+    <recipe result='Warn' status='Waiting' id="123123">
+      <logs>
+        <log name='console.log' href="http://example.com/">
+          TEST RESULT
+        </log>
+      </logs>
+      <task name='/test/misc/machineinfo'>
+        <logs>
+          <log name='machinedesc.log' href="http://example.com/machinedesc.log">
+          </log>
+          <log name='lshw.log' href="http://example.com/lshw.log">
+          </log>
+        </logs>
+      </task>
+      <task name='/distribution/install' result='Fail'>
+      </task>
+    </recipe>
+  </recipeSet>
+</job>

--- a/tests/assets/beaker_results2.xml
+++ b/tests/assets/beaker_results2.xml
@@ -11,8 +11,7 @@
           TEST RESULT
         </log>
       </logs>
-      <task name="/test/misc/boottest" result="Failed"><fetch url="kpkginstall"/></task>
-      <task name='/test/misc/machineinfo' result="Failed">
+      <task name='/test/misc/machineinfo'>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">
           </log>

--- a/tests/assets/beaker_results3.xml
+++ b/tests/assets/beaker_results3.xml
@@ -11,8 +11,8 @@
           TEST RESULT
         </log>
       </logs>
-      <task name="/test/misc/boottest" result="Failed"><fetch url="kpkginstall"/></task>
-      <task name='/test/misc/machineinfo' result="Failed">
+      <task name="/test/misc/boottest" result="Pass"><fetch url="kpkginstall"/></task>
+      <task name='/test/misc/machineinfo' result="Pass">
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">
           </log>
@@ -20,6 +20,8 @@
           </log>
         </logs>
       </task>
+
     </recipe>
   </recipeSet>
+
 </job>

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -14,6 +14,8 @@
 """Miscellaneous for tests."""
 import os
 
+import mock
+from defusedxml.ElementTree import fromstring
 
 ASSETS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'assets')
 
@@ -39,3 +41,83 @@ def get_asset_content(filename):
     """
     with open(get_asset_path(filename)) as asset:
         return asset.read()
+
+
+def fake_cancel_pending_jobs(sself):
+    """Cancel pending job without calling 'bkr cancel'.
+
+    Args:
+        sself: BeakerRunner
+    Returns:
+        None
+    """
+    # pylint: disable=protected-access,
+    for job_id in set(sself.job_to_recipe_set_map):
+        sself._BeakerRunner__forget_taskspec(job_id)
+
+
+def exec_on(myrunner, mock_jobsubmit, xml_asset_file, max_aborted,
+            alt_state=None):
+    """Simulate getting live results from Beaker.
+    Feed skt/runner with an XML and change it after a couple of runs.
+
+    Args:
+        myrunner:       BeakerRunner
+        mock_jobsubmit: mock object for __jobsubmit
+        xml_asset_file: xml filename to use
+        max_aborted:    Maximum number of allowed aborted jobs. Abort the
+                        whole stage if the number is reached.
+        alt_state:      if set, represents a state to transition the job to
+    Returns:
+        BeakerRunner run() result
+
+    """
+    # pylint: disable=W0613
+    def fake_getresultstree(sself, taskspec):
+        """Fakt getresultstree. Change state of last recipe on 3rd loop.
+
+        Args:
+             sself:    BeakerRunner
+             taskspec: ID of the job, recipe or recipe set.
+        Returns:
+            xml root
+        """
+        if alt_state:
+            if fake_getresultstree.run_count > 2:
+                result = fromstring(get_asset_content(xml_asset_file))
+
+                recipe = result.findall('.//recipe')[-1]
+                recipe.attrib['status'] = alt_state
+
+                return result
+
+            fake_getresultstree.run_count += 1
+
+        return fromstring(get_asset_content(xml_asset_file))
+
+    fake_getresultstree.run_count = 1
+    # fake cancel_pending_jobs so 'bkr cancel' isn't run
+    mock1 = mock.patch('skt.runner.BeakerRunner.cancel_pending_jobs',
+                       fake_cancel_pending_jobs)
+    mock1.start()
+
+    # fake getresultstree, so we can change XML input during testrun
+    mock2 = mock.patch('skt.runner.BeakerRunner.getresultstree',
+                       fake_getresultstree)
+    mock2.start()
+
+    url = "http://machine1.example.com/builds/1234567890.tar.gz"
+    release = "4.17.0-rc1"
+    wait = True
+
+    mock_jobsubmit.return_value = "J:0001"
+
+    # no need to wait 60 seconds
+    # though beaker_pass_results.xml only needs one iteration
+    myrunner.watchdelay = 0.01
+
+    result = myrunner.run(url, max_aborted, release, wait)
+
+    mock1.stop()
+    mock2.stop()
+    return result

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -448,3 +448,75 @@ class TestRunner(unittest.TestCase):
         result = self.myrunner.run(url, self.max_aborted, release, wait)
         # Don't compare the report strings
         self.assertEqual(result[0], 0)
+
+    @mock.patch('logging.warning')
+    @mock.patch('logging.error')
+    @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
+    def test_run_wait2(self, mock_logging, mock_logging_err, mock_jobsubmit):
+        """Ensure BeakerRunner.run works."""
+        # pylint: disable=W0613
+
+        misc.exec_on(self.myrunner, mock_jobsubmit, 'beaker_results.xml', 1,
+                     'Completed')
+
+    @mock.patch('logging.warning')
+    @mock.patch('logging.error')
+    @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
+    def test_run_wait3(self, mock_logging, mock_logging_err, mock_jobsubmit):
+        """Ensure BeakerRunner.run works."""
+        # pylint: disable=W0613
+
+        misc.exec_on(self.myrunner, mock_jobsubmit, 'beaker_results2.xml', 1,
+                     'Completed')
+
+    @mock.patch('logging.warning')
+    @mock.patch('logging.error')
+    @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
+    def test_run_wait4(self, mock_logging, mock_logging_err, mock_jobsubmit):
+        """Ensure BeakerRunner.run works."""
+        # pylint: disable=W0613
+
+        misc.exec_on(self.myrunner, mock_jobsubmit, 'beaker_results3.xml', 1,
+                     'Completed')
+
+    @mock.patch('logging.warning')
+    @mock.patch('logging.error')
+    @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
+    def test_run_wait5(self, mock_logging, mock_logging_err, mock_jobsubmit):
+        """Ensure BeakerRunner.run works."""
+        # pylint: disable=W0613
+
+        misc.exec_on(self.myrunner, mock_jobsubmit, 'beaker_results3.xml', 2,
+                     'Completed')
+
+    @mock.patch('logging.warning')
+    @mock.patch('logging.error')
+    @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
+    def test_run_wait6(self, mock_logging, mock_logging_err, mock_jobsubmit):
+        """Ensure BeakerRunner.run works."""
+        # pylint: disable=W0613
+
+        # abort right-away ( 0 allowed)
+        misc.exec_on(self.myrunner, mock_jobsubmit, 'beaker_aborted_some.xml',
+                     0)
+
+    @mock.patch('logging.warning')
+    @mock.patch('logging.error')
+    @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
+    def test_run_wait7(self, mock_logging, mock_logging_err, mock_jobsubmit):
+        """Ensure BeakerRunner.run works."""
+        # pylint: disable=W0613
+
+        # abort later on, change last recipe to Aborted
+        misc.exec_on(self.myrunner, mock_jobsubmit, 'beaker_aborted_some.xml',
+                     2, 'Aborted')
+
+    @mock.patch('logging.warning')
+    @mock.patch('logging.error')
+    @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
+    def test_run_wait8(self, mock_logging, mock_logging_err, mock_jobsubmit):
+        """Ensure BeakerRunner.run works."""
+        # pylint: disable=W0613
+
+        misc.exec_on(self.myrunner, mock_jobsubmit, 'beaker_aborted_some.xml',
+                     5, 'Cancelled')


### PR DESCRIPTION
This adds a couple of tests for skt/runner.py:run. The tests feed some XMLs to run() and change one of the recipes to state like Completed or Aborted to hit different code branches. 