### PR TITLE
silence/fix "Could not cancel job" bug

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -267,10 +267,16 @@ class BeakerRunner(Runner):
         """
         Cancel all recipe sets from self.watchlist and remove their IDs from
         self.job_to_recipe_set_map.
+        Cancelling a part of a job leads to cancelling the entire job.
+        So we cancel a job if any of its recipesets is in the watchlist.
         """
         sets_to_cancel = [recipe_set for recipe_set in self.watchlist.copy()]
         if sets_to_cancel:
-            ret = subprocess.call(['bkr', 'job-cancel'] + sets_to_cancel)
+            jobs2cancel = filter(lambda job_id: self.job_to_recipe_set_map[
+                job_id].intersection(self.watchlist),
+                                 self.job_to_recipe_set_map)
+
+            ret = subprocess.call(['bkr', 'job-cancel'] + jobs2cancel)
             if ret:
                 logging.info('Failed to cancel the remaining recipe sets!')
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -138,7 +138,7 @@ class TestRunner(unittest.TestCase):
         mock_popen.assert_called()
 
         binary = 'bkr'
-        args = ['job-cancel'] + [s for s in self.myrunner.watchlist]
+        args = ['job-cancel', j_jobid]
 
         attrs = {'communicate.return_value': ('output', 'error'),
                  'returncode': 0}


### PR DESCRIPTION
We get error like

"""
XML-RPC fault: <class 'bkr.common.bexceptions.BX'>:Could not cancel job
id 5105713. Please try later
"""

when jobs are cancelled. This is because Beaker cancels entire jobs when
asked to cancel any of recipsets of that job and afterwards we try to
cancel a job already cancelled.

This patch adjusts cancel_pending_jobs() and its test.
We cancel entire jobs, if they have any recipeset in watchlist.
(Watchlist contains only recipsets.) This way the code shouldn't try to
cancel anything else than watchlist.

Signed-off-by: Jakub Racek <jracek@redhat.com>