### PR TITLE
Add support for --mail-subject-pfx option

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -735,6 +735,11 @@ def setup_parser():
         help="Report sender's email address"
     )
     parser_report.add_argument(
+        "--mail-subject-pfx",
+        type=str,
+        help="Prefix to add to the subject of the report email"
+    )
+    parser_report.add_argument(
         "--mail-subject",
         type=str,
         help="Subject of the report email"
@@ -919,6 +924,7 @@ def load_config(args):
             'mail_cc': cfg.get('mail_cc'),
             'mail_bcc': cfg.get('mail_bcc'),
             'mail_from': cfg.get('mail_from'),
+            'mail_subject_pfx': cfg.get('mail_subject_pfx'),
             'mail_subject': cfg.get('mail_subject'),
             'mail_header': cfg.get('mail_header')
         }

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -516,6 +516,7 @@ class MailReporter(Reporter):
                         for bcc in cfg['reporter']['mail_bcc'] or []]
         self.headers = [headers.strip() for headers in
                         cfg['reporter']['mail_header']]
+        self.subject_pfx = cfg['reporter']['mail_subject_pfx']
         self.subject = cfg['reporter']['mail_subject']
         self.smtp_url = cfg.get('smtp_url') or 'localhost'
 
@@ -532,8 +533,6 @@ class MailReporter(Reporter):
         msg = MIMEMultipart()
 
         # Add the most basic parts of the email message
-        if self.subject:
-            msg['Subject'] = self.subject
         msg['To'] = ', '.join(self.mailto)
         msg['Cc'] = ', '.join(self.mailcc)
         msg['From'] = self.mailfrom
@@ -546,8 +545,16 @@ class MailReporter(Reporter):
         # We need to run the reporting function first to get aggregates to
         # build subject from
         msg.attach(MIMEText(self._get_multireport()))
-        if not msg['Subject']:
-            msg['Subject'] = self._get_multisubject()
+
+        # Assign subject
+        if self.subject:
+            subject = self.subject
+        else:
+            subject = self._get_multisubject()
+        if self.subject_pfx:
+            subject = self.subject_pfx + subject
+        msg['Subject'] = subject
+
         # Add the SKT job IDs so we can correlate emails to jobs
         msg['X-SKT-JIDS'] = ' '.join(self.multi_job_ids)
 


### PR DESCRIPTION
Add support for specifying --mail-subject-pfx option, which value would
be added to either generated or specified "Subject:" header of the
report message.

That would allow sending baseline reports with a "Waiting for review"
prefix.

This is required for fixing the addition of "Waiting for review: "
to subjects in the reporter.