### PR TITLE
Pass args to cmd_merge(), not cfg

### DIFF
--- a/skt/state_file.py
+++ b/skt/state_file.py
@@ -12,6 +12,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Functions that manage the skt state file."""
+import ConfigParser
 import logging
 import os
 import yaml
@@ -83,3 +84,30 @@ def update(cfg, state_updates):
     except IOError as exception:
         logging.error("Failed to update state file: %s", exception)
         raise exception
+
+
+def update_state(state_file, state_dict):
+    """
+    Write updated state information to the state file.
+
+    Args:
+        state_file: Path to state file.
+        state_dict: A dictionary of key/value pairs to update in statefile.
+    """
+    config = ConfigParser.RawConfigParser()
+
+    # If the state file exists, read its current values.
+    if os.path.isfile(state_file):
+        config.read(state_file)
+
+    # Add a 'state' section if it doesn't exist already.
+    if not config.has_section("state"):
+        config.add_section("state")
+
+    # Iterate over the state_dict and update key/value pairs.
+    for (key, val) in state_dict.iteritems():
+        config.set('state', key, val)
+
+    # Write the update state file to disk.
+    with open(state_file, 'w') as fileh:
+        config.write(fileh)

--- a/skt/state_file.py
+++ b/skt/state_file.py
@@ -13,77 +13,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Functions that manage the skt state file."""
 import ConfigParser
-import logging
 import os
-import yaml
-
-
-def destroy(cfg):
-    """
-    Destroy the state file.
-
-    Args:
-        cfg: A dictionary of skt configuration
-    """
-    state_file = cfg.get('state')
-
-    if os.path.isfile(state_file):
-        try:
-            os.unlink(state_file)
-        except IOError as exception:
-            logging.error("Failed to delete state file: %s", exception)
-            raise exception
-
-
-def read(cfg):
-    """
-    Read the state file from the disk.
-
-    Args:
-        cfg: A dictionary of skt configuration
-    """
-    # Return an empty state dictionary if the state file does not exist
-    current_state = {}
-
-    state_file = cfg.get('state')
-    logging.debug("Reading state from: %s", state_file)
-
-    if os.path.isfile(state_file):
-        try:
-            with open(state_file, 'r') as fileh:
-                current_state = yaml.load(fileh)
-        except IOError as exception:
-            logging.error("Failed to read state file: %s", exception)
-            raise exception
-
-    return current_state
-
-
-def update(cfg, state_updates):
-    """
-    Update the state file on disk with new state data.
-
-    Args:
-        cfg:           A dictionary of skt configuration.
-        state_updates: A dictionary of items to update.
-    """
-    current_state = read(cfg)
-
-    # Merge the current state and the updates.
-    new_state = current_state.copy()
-    new_state.update(state_updates)
-
-    # Save the new state to the state file
-    logging.debug("Saving state: %s", state_updates)
-    state_file = cfg.get('state')
-
-    try:
-        with open(state_file, 'w') as fileh:
-            yaml_state = yaml.dump(new_state, default_flow_style=False)
-            fileh.write(yaml_state)
-    except IOError as exception:
-        logging.error("Failed to update state file: %s", exception)
-        raise exception
 
 
 def update_state(state_file, state_dict):

--- a/tests/test_state_file.py
+++ b/tests/test_state_file.py
@@ -18,8 +18,6 @@ import shutil
 import tempfile
 import unittest
 
-import mock
-
 from skt import state_file
 
 
@@ -34,10 +32,6 @@ class TestStateFile(unittest.TestCase):
     def setUp(self):
         """Text fixtures."""
         self.tmpdir = tempfile.mkdtemp()
-        self.tempstate = "{}/state.yml".format(self.tmpdir)
-        with open(self.tempstate, 'w') as fileh:
-            fileh.write("---\noption: value")
-        self.cfg = {'state': self.tempstate}
 
     def tearDown(self):
         """Teardown steps when testing is complete."""
@@ -45,75 +39,6 @@ class TestStateFile(unittest.TestCase):
         # before deleting it.
         if os.path.isdir(self.tmpdir):
             shutil.rmtree(self.tmpdir)
-
-    def test_destroy_state_file(self):
-        """Ensure destroy() deletes the state file."""
-        state_file.destroy(self.cfg)
-        self.assertFalse(os.path.isfile(self.cfg['state']))
-
-    def test_destroy_state_file_missing(self):
-        """Ensure destroy() checks to see if the state file exists."""
-        os.unlink(self.tempstate)
-        state_file.destroy(self.cfg)
-        self.assertFalse(os.path.isfile(self.cfg['state']))
-
-    @mock.patch('logging.error')
-    @mock.patch('os.unlink', side_effect=exception_maker)
-    def test_destroy_state_file_failure(self, mock_unlink, mock_logging):
-        """Ensure destroy() fails when state file cannot be deleted."""
-        # pylint: disable=W0613
-        with self.assertRaises(IOError):
-            state_file.destroy(self.cfg)
-
-        mock_logging.assert_called_once()
-
-    def test_read_state_file(self):
-        """Ensure read() reads the state file."""
-        test_yaml = state_file.read(self.cfg)
-        self.assertDictEqual(test_yaml, {'option': 'value'})
-
-    def test_read_state_file_missing(self):
-        """Ensure read() checks to see if the state file exists.."""
-        os.unlink(self.tempstate)
-        test_yaml = state_file.read(self.cfg)
-        self.assertDictEqual(test_yaml, {})
-
-    @mock.patch('logging.error')
-    @mock.patch('yaml.load', side_effect=exception_maker)
-    def test_read_state_file_failure(self, mock_yaml, mock_logging):
-        """Ensure read() fails when state file is unreadable."""
-        # pylint: disable=W0613
-        with self.assertRaises(IOError):
-            state_file.read(self.cfg)
-
-        mock_logging.assert_called_once()
-
-    def test_update(self):
-        """Ensure update() updates the state file."""
-        # Write some new state
-        new_state = {'foo2': 'bar2'}
-        state_file.update(self.cfg, new_state)
-
-        # Read in the state file to verify the new state was written
-        state_data = state_file.read(self.cfg)
-
-        expected_dict = {
-            'option': 'value',
-            'foo2': 'bar2',
-        }
-        self.assertDictEqual(state_data, expected_dict)
-
-    @mock.patch('logging.error')
-    @mock.patch('yaml.dump', side_effect=exception_maker)
-    def test_update__failure(self, mock_yaml, mock_logging):
-        """Ensure update() fails when the state file cannot be updated."""
-        # pylint: disable=W0613
-        # Write some new state
-        new_state = {'foo2': 'bar2'}
-        with self.assertRaises(IOError):
-            state_file.update(self.cfg, new_state)
-
-        mock_logging.assert_called_once()
 
     def test_update_state(self):
         """Ensure update_state() writes a state file."""


### PR DESCRIPTION
Pass the command line arguments directly to `cmd_merge` and update
the state file directly without passing around the entire `cfg`
object.

The goal is to treat the state file like a state file and not a
config file. We should be doing just-in-time reads from and writes
to the state file (treating it more like a database).

Signed-off-by: Major Hayden <major@redhat.com>