### PR TITLE
Use loggers for file/stdout output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,10 @@ defaults: &defaults
                 --cfgtype tinyconfig
         working_directory: /tmp/skt_test
     - run:
+        name: Display build log
+        command: cat workdir/build.log
+        working_directory: /tmp/skt_test
+    - run:
         name: Test `skt report`
         command: |
             skt -vv --state -d workdir --rc sktrc report \

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -63,6 +63,9 @@ class KernelBuilder(object):
         else:
             self.extra_make_args = []
 
+        # Truncate the buildlog, if it exists.
+        self.__reset_build_log()
+
         logging.info("basecfg: %s", self.basecfg)
         logging.info("cfgtype: %s", self.cfgtype)
 
@@ -170,6 +173,12 @@ class KernelBuilder(object):
             return os.environ['ARCH']
 
         return platform.machine()
+
+    def __reset_build_log(self):
+        """Truncate the build log."""
+        if os.path.isfile(self.buildlog):
+            with open(self.buildlog, 'w') as fileh:
+                fileh.write('')
 
     @classmethod
     def __get_cross_compiler_prefix(cls):


### PR DESCRIPTION
Add a new `run_multipipe` function that uses Python's logging module
to simultaneously write to a log file and stdout. All uses of
check_output/check_call are replaced with the new method.

This patch also includes updated tests.
