### PR TITLE
Add RPM support, 100% kernelbuilder test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ defaults: &defaults
             --fetch-depth 1
         working_directory: /tmp/skt_test
     - run:
-        name: Test `skt build`
+        name: Test `skt build` with tarball
         command: |
             skt -vv --state -d workdir --rc sktrc build -c config \
                 --cfgtype tinyconfig
@@ -35,6 +35,12 @@ defaults: &defaults
         command: |
             skt -vv --state -d workdir --rc sktrc report \
                 --reporter stdio
+        working_directory: /tmp/skt_test
+    - run:
+        name: Test `skt build` with RPM
+        command: |
+            skt -vv --state -d workdir --rc sktrc build -c config \
+                --cfgtype tinyconfig --make-target binrpm-pkg
         working_directory: /tmp/skt_test
     - store_artifacts:
         path: /tmp/skt_test/workdir/*.log


### PR DESCRIPTION
This PR includes several improvements for `kernelbuilder`:

* Refactors kernel compiles to use a common method
* kernelbuilder now supports `targz-pkg` as well as `binrpm-pkg`

Kernel compiles start with `compile_kernel()`. Config is prepared and the kernel is compiled. Upon completion, `handle_tarball()` or `handle_rpm()` can be called to find kernel packages and prepare them for publishing.