### PR TITLE
Remove junit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dependencies
 
 Install dependencies needed for running skt like this:
 
-    sudo dnf install -y python2 python2-junit_xml beaker-client
+    sudo dnf install -y python2 beaker-client
 
 Dependencies needed to build kernels:
 
@@ -120,10 +120,6 @@ reporting the results.
 All the following commands use the `-vv` option to increase verbosity of the
 command's output, so it's easier to debug problems. Remove the option for
 quieter, shorter output.
-
-You can make `skt` output junit-compatible results by adding a `--junit
-<JUNIT_DIR>` option to any of the following commands. The results will be
-written to the `<JUNIT_DIR>` directory.
 
 ### Merge
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ include_package_data = True
 # Let pip install dependencies automatically.
 install_requires = flake8
                    jinja2>=2.10
-                   junit_xml
                    mock
                    defusedxml
                    responses

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -30,8 +30,6 @@ import tempfile
 import time
 import traceback
 
-import junit_xml
-
 import skt
 import skt.console
 import skt.publisher
@@ -126,72 +124,6 @@ def save_state(cfg, state):
         config.write(fileh)
 
 
-def junit(func):
-    """
-    Create a function accepting a configuration object and passing it to
-    the specified function, putting the call results into a JUnit test case,
-    if configuration has JUnit result directory specified, simply calling the
-    function otherwise.
-
-    The generated test case is named "skt.<function-name>". The case stdout is
-    set to JSON representation of the configuration object after the function
-    call has completed. The created test case is appended to the "_testcases"
-    list in the configuration object after that. Sets the global "retcode" to
-    SKT_SUCCESS in case of test success, SKT_FAIL in case of test failure, and
-    SKT_ERROR and above in case of infrastructure failure or skt problem (eg.
-    Beaker server is unreachable).
-
-    Args:
-        func:   The function to call in the created function. Must accept
-                a configuration object as the argument. Return value would be
-                ignored. Can set the global "retcode" to indicate success
-                (SKT_SUCCESS), test failure (SKT_FAIL) or infrastructure
-                failure (SKT_ERROR and above).
-
-    Return:
-        The created function.
-    """
-    def wrapper(cfg):
-        """
-        Outer wrapper of a @junit function.
-        Args:
-            cfg: A dictionary of skt configuration
-
-        """
-        # pylint: disable=broad-except
-        global retcode
-        if cfg.get('junit'):
-            tstart = time.time()
-            testcase = junit_xml.TestCase(func.__name__, classname="skt")
-
-            try:
-                func(cfg)
-            except Exception:
-                logging.error("Unexpected exception caught, probably an "
-                              "infrastructure failure or skt bug: %s",
-                              traceback.format_exc())
-                testcase.add_error_info(traceback.format_exc())
-                retcode = SKT_ERROR
-
-            if retcode == SKT_FAIL:
-                # Tests failed
-                testcase.add_failure_info("Step finished with retcode: %d" %
-                                          retcode)
-            elif retcode >= SKT_ERROR:
-                testcase.add_error_info(
-                    "Infrastructure issue or skt bug detected, retcode: %d" %
-                    retcode
-                )
-
-            testcase.stdout = json.dumps(cfg, default=str)
-            testcase.elapsed_sec = time.time() - tstart
-            cfg['_testcases'].append(testcase)
-        else:
-            func(cfg)
-    return wrapper
-
-
-@junit
 def cmd_merge(args):
     """
     Fetch a kernel repository, checkout particular references, and optionally
@@ -311,7 +243,6 @@ def cmd_merge(args):
     update_state(args['rc'], state)
 
 
-@junit
 def cmd_build(args):
     """
     Build the kernel with specified configuration and put it into a tarball.
@@ -409,7 +340,6 @@ def cmd_build(args):
         logging.error('No config file to copy found!')
 
 
-@junit
 def cmd_publish(cfg):
     """
     Publish (copy) the kernel tarball and configuration to the specified
@@ -433,7 +363,6 @@ def cmd_publish(cfg):
         logging.debug('No kernel tarball to publish found!')
 
 
-@junit
 def cmd_run(cfg):
     """
     Run tests on a built kernel using the specified "runner". Only "Beaker"
@@ -607,10 +536,6 @@ def setup_parser():
         "--output-dir",
         type=str,
         help="Path to output directory"
-    )
-    parser.add_argument(
-        "--junit",
-        help="Directory for storing junit XML results"
     )
     parser.add_argument(
         "-v",
@@ -1032,12 +957,6 @@ def load_config(args):
     for idx, statefile_path in enumerate(cfg.get('result') or []):
         cfg['result'][idx] = full_path(statefile_path)
 
-    if cfg.get('junit'):
-        try:
-            os.mkdir(full_path(cfg.get('junit')))
-        except OSError:
-            pass
-
     # Assign default max aborted count if it's not defined in config file
     if not cfg.get('max_aborted_count'):
         cfg['max_aborted_count'] = 3
@@ -1116,12 +1035,6 @@ def main():
         else:
             cfg = load_config(args)
             args.func(cfg)
-
-        if cfg.get('junit'):
-            testsuite = junit_xml.TestSuite("skt", cfg.get('_testcases'))
-            with open("%s/%s.xml" % (cfg.get('junit'), args._name),
-                      'w') as fileh:
-                junit_xml.TestSuite.to_file(fileh, [testsuite])
 
         sys.exit(retcode)
     except KeyboardInterrupt:

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -165,7 +165,7 @@ class TestExecutable(unittest.TestCase):
 
         ]
         args = ['--rc', '/tmp/testing.ini', '--workdir', '/tmp/workdir',
-                '--state', '--junit', '/tmp/junit', 'report', '--reporter',
+                '--state', 'report', '--reporter',
                 'stdio', '--result', '/tmp/state.txt']
         cfg = self.load_config_tester(config_file, args)
         self.assertEqual('bar', cfg['foo'])
@@ -320,47 +320,3 @@ class TestExecutable(unittest.TestCase):
         current_logger = logging.getLogger('executable')
         self.assertEqual(current_logger.getEffectiveLevel(), logging.WARNING -
                          (verbose * 10))
-
-    def test_junit(self):
-        """Ensure junit works and creates a callable wrapper."""
-        def test_func(cfg):
-            """ A function to wrap and run."""
-            cfg['called'] = True
-            return cfg
-
-        cfg = {'junit': 'whatever', '_testcases': ['test_setup_logging']}
-        func_wrapper = executable.junit(test_func)
-        func_wrapper(cfg)
-        self.assertTrue(cfg['called'])
-
-    @mock.patch('logging.error')
-    def test_junit_raise(self, mock_logging):
-        """Ensure junit works and creates a callable wrapper and
-            returns SKT_ERROR (2) on exception. """
-        # pylint: disable=unused-argument
-        def test_func(cfg):
-            """ A function to wrap and run."""
-            raise RuntimeError('Objectiooooooon!')
-
-        cfg = {'junit': 'whatever', '_testcases': ['test_setup_logging']}
-
-        func_wrapper = executable.junit(test_func)
-
-        func_wrapper(cfg)
-        self.assertEqual(executable.retcode, 2)
-
-    @mock.patch('logging.error')
-    def test_junit_set_errcode(self, mock_logging):
-        """Ensure junit works and creates a callable wrapper and
-            that the method may modify retcode. """
-        # pylint: disable=unused-argument
-        def test_func(cfg):
-            """ A function to wrap and run."""
-            executable.retcode = 1
-
-        cfg = {'junit': 'whatever', '_testcases': ['test_setup_logging']}
-
-        func_wrapper = executable.junit(test_func)
-
-        func_wrapper(cfg)
-        self.assertEqual(executable.retcode, 1)


### PR DESCRIPTION
With the days of Jenkins long behind us, let's retire the junit code.

Signed-off-by: Major Hayden <major@redhat.com>