### PR TITLE
Add --make-target argument

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -331,6 +331,7 @@ def cmd_build(args):
         extra_make_args=args.get('makeopts'),
         enable_debuginfo=args.get('enable_debuginfo'),
         rh_configs_glob=args.get('rh_configs_glob'),
+        make_target=args.get('make_target'),
         localversion=args.get('localversion')
     )
 
@@ -718,6 +719,14 @@ def setup_parser():
         "--makeopts",
         type=str,
         help="Additional options to pass to make"
+    )
+    parser_build.add_argument(
+        "--make-target",
+        dest="make_target",
+        type=str,
+        default='targz-pkg',
+        choices=('targz-pkg', 'binrpm-pkg'),
+        help="Make target from kernel Makefile"
     )
     parser_build.add_argument(
         "--rh-configs-glob",

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -34,7 +34,8 @@ class KernelBuilder(object):
     # pylint: disable=too-many-instance-attributes,too-many-arguments
     def __init__(self, source_dir, basecfg, cfgtype=None,
                  extra_make_args=None, enable_debuginfo=False,
-                 rh_configs_glob=None, localversion=None):
+                 rh_configs_glob=None, localversion=None,
+                 make_target=None):
         self.source_dir = source_dir
         self.basecfg = basecfg
         self.cfgtype = cfgtype if cfgtype is not None else "olddefconfig"
@@ -48,6 +49,7 @@ class KernelBuilder(object):
         self.cross_compiler_prefix = self.__get_cross_compiler_prefix()
         self.rh_configs_glob = rh_configs_glob
         self.localversion = localversion
+        self.make_target = None
 
         self.targz_pkg_argv = [
             "INSTALL_MOD_STRIP=1",


### PR DESCRIPTION
This argument allows a user to specify a custom make target. Only
targz-pkg is supported for now.

Signed-off-by: Major Hayden <major@redhat.com>