### PR TITLE
Remove junit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dependencies
 
 Install dependencies needed for running skt like this:
 
-    sudo dnf install -y python2 python2-junit_xml beaker-client
+    sudo dnf install -y python2 beaker-client
 
 Dependencies needed to build kernels:
 
@@ -120,10 +120,6 @@ reporting the results.
 All the following commands use the `-vv` option to increase verbosity of the
 command's output, so it's easier to debug problems. Remove the option for
 quieter, shorter output.
-
-You can make `skt` output junit-compatible results by adding a `--junit
-<JUNIT_DIR>` option to any of the following commands. The results will be
-written to the `<JUNIT_DIR>` directory.
 
 ### Merge
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ include_package_data = True
 # Let pip install dependencies automatically.
 install_requires = flake8
                    jinja2>=2.10
-                   junit_xml
                    mock
                    defusedxml
                    responses

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -165,7 +165,7 @@ class TestExecutable(unittest.TestCase):
 
         ]
         args = ['--rc', '/tmp/testing.ini', '--workdir', '/tmp/workdir',
-                '--state', '--junit', '/tmp/junit', 'report', '--reporter',
+                '--state', 'report', '--reporter',
                 'stdio', '--result', '/tmp/state.txt']
         cfg = self.load_config_tester(config_file, args)
         self.assertEqual('bar', cfg['foo'])
@@ -320,47 +320,3 @@ class TestExecutable(unittest.TestCase):
         current_logger = logging.getLogger('executable')
         self.assertEqual(current_logger.getEffectiveLevel(), logging.WARNING -
                          (verbose * 10))
-
-    def test_junit(self):
-        """Ensure junit works and creates a callable wrapper."""
-        def test_func(cfg):
-            """ A function to wrap and run."""
-            cfg['called'] = True
-            return cfg
-
-        cfg = {'junit': 'whatever', '_testcases': ['test_setup_logging']}
-        func_wrapper = executable.junit(test_func)
-        func_wrapper(cfg)
-        self.assertTrue(cfg['called'])
-
-    @mock.patch('logging.error')
-    def test_junit_raise(self, mock_logging):
-        """Ensure junit works and creates a callable wrapper and
-            returns SKT_ERROR (2) on exception. """
-        # pylint: disable=unused-argument
-        def test_func(cfg):
-            """ A function to wrap and run."""
-            raise RuntimeError('Objectiooooooon!')
-
-        cfg = {'junit': 'whatever', '_testcases': ['test_setup_logging']}
-
-        func_wrapper = executable.junit(test_func)
-
-        func_wrapper(cfg)
-        self.assertEqual(executable.retcode, 2)
-
-    @mock.patch('logging.error')
-    def test_junit_set_errcode(self, mock_logging):
-        """Ensure junit works and creates a callable wrapper and
-            that the method may modify retcode. """
-        # pylint: disable=unused-argument
-        def test_func(cfg):
-            """ A function to wrap and run."""
-            executable.retcode = 1
-
-        cfg = {'junit': 'whatever', '_testcases': ['test_setup_logging']}
-
-        func_wrapper = executable.junit(test_func)
-
-        func_wrapper(cfg)
-        self.assertEqual(executable.retcode, 1)


### PR DESCRIPTION
Now that Jenkins is no longer being used with skt, let's remove junit
support and reduce our dependencies.

Signed-off-by: Major Hayden <major@redhat.com>