### PR TITLE
Actually use args for merge/build

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -1041,8 +1041,9 @@ def main():
 
         # We are gradually migrating away from messing with cfg and passing
         # it everywhere.
-        if args.func in ['cmd_merge', 'cmd_build']:
-            args.func(args)
+        var_args = vars(args)
+        if var_args['_name'] in ['merge', 'build']:
+            args.func(var_args)
         else:
             cfg = load_config(args)
             args.func(cfg)


### PR DESCRIPTION
A previous commit tried to use `args` instead of `cfg`, but the logic
was so bad that the condition was never reached and `cmd_merge` and
`cmd_build` were still being called with `cfg`. 😂

Convert the args to vars and properly pass args along to merge/build
commands.

Signed-off-by: Major Hayden <major@redhat.com>