### PR TITLE
Refactor/simplify publisher; RPM repo support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,13 @@ defaults: &defaults
         command: cat workdir/build.log
         working_directory: /tmp/skt_test
     - run:
+        name: Publish results with cp
+        command: |
+            mkdir /tmp/published
+            skt -vv --state -d workdir --rc sktrc publish \
+                --publisher cp /tmp/published http://localhost/published
+        working_directory: /tmp/skt_test
+    - run:
         name: Test `skt report`
         command: |
             skt -vv --state -d workdir --rc sktrc report \

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -12,15 +12,99 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Test cases for publisher module."""
+import os
+import shutil
+import tempfile
 import unittest
+
+import mock
 
 from skt import publisher
 
 
 class TestPublisher(unittest.TestCase):
     """Test cases for publisher.Publisher class."""
-    def test_geturl(self):
-        """Check if the source url is built correctly."""
-        for cls in publisher.Publisher.__subclasses__():
-            pub = cls('dest', 'file:///tmp/test')
-            self.assertEqual(pub.geturl('source'), 'file:///tmp/test/source')
+
+    def setUp(self):
+        """Test fixtures."""
+        self.tmpdir = tempfile.mkdtemp()
+
+        self.pub = publisher.Publisher(
+            pub_type='cp',
+            source="{}/kernel.tar.gz".format(self.tmpdir),
+            dest="{}/published".format(self.tmpdir),
+            baseurl="http://localhost/published"
+        )
+
+    def tearDown(self):
+        """Tear down test fixtures."""
+        shutil.rmtree(self.tmpdir)
+
+    def test_cp_file(self):
+        """Test cp with a file."""
+        # Create a test file.
+        temp_file = "{}/kernel.tar.gz".format(self.tmpdir)
+        with open(temp_file, 'w') as fileh:
+            fileh.write("Kernel data")
+
+        # Add an existing publish directory to ensure that publisher won't
+        # try to create it again.
+        if not os.path.isdir(self.pub.destination):
+            os.mkdir(self.pub.destination)
+
+        # Test with a file.
+        self.pub.publish()
+
+        # Ensure the file is present with the right data inside.
+        self.assertTrue(os.path.isfile(temp_file))
+        with open(temp_file, 'r') as fileh:
+            self.assertEqual(fileh.read(), "Kernel data")
+
+    def test_cp_directory(self):
+        """Test cp with a directory."""
+        # Create a test directory with files.
+        repo_dir = "{}/repo_dir".format(self.tmpdir)
+        os.mkdir(repo_dir)
+
+        with open("{}/kernel.rpm".format(repo_dir), 'w') as fileh:
+            fileh.write("Kernel RPM data")
+
+        # Test with a directory.
+        self.pub.source = repo_dir
+        self.pub.publish()
+
+        # Verify that the directory was made.
+        published_dir = "{}/published/repo_dir".format(self.tmpdir)
+        self.assertTrue(os.path.isdir(published_dir))
+
+        # Try it once more to ensure that the RPM repo dir will be removed
+        # and re-created.
+        self.pub.publish()
+        self.assertTrue(os.path.isdir(published_dir))
+
+    @mock.patch('subprocess.check_call')
+    def test_scp_file(self, mock_call):
+        """Test scp with a file."""
+        # Create a test file.
+        temp_file = "{}/kernel.tar.gz".format(self.tmpdir)
+        with open(temp_file, 'w') as fileh:
+            fileh.write("Kernel data")
+
+        # Test with a file.
+        self.pub.pub_type = 'scp'
+        self.pub.publish()
+
+        check_call_args = mock_call.call_args[0]
+        expected_call_args = [
+            'scp',
+            '-r',
+            self.pub.source,
+            self.pub.destination
+        ]
+        self.assertEqual(check_call_args[0], expected_call_args)
+
+    def test_invalid_publisher(self):
+        """Verify that an exception occurs with an invalid publisher."""
+        self.pub.pub_type = 'unladen_swallow'
+        with self.assertRaises(KeyError):
+            self.pub.publish()


### PR DESCRIPTION
This PR includes:

- Testing for `skt publish` in CircleCI
- A refactor and simplification of the `Publisher` class
- Support for publishing directories, such as RPM repositories recursively
- Just-in-time state file writes/reads for `cmd_publish()`
- Removal of the unused `sftp` publisher
- Full test coverage for `Publisher` class