### PR TITLE
Record make_opts as a string

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -273,7 +273,7 @@ def cmd_build(args):
     make_opts = builder.assemble_make_options()
     state = {
         'kernel_arch': kernel_arch,
-        'make_opts': make_opts
+        'make_opts': ' '.join(make_opts)
     }
     update_state(args['rc'], state)
 


### PR DESCRIPTION
The report portion of skt expects `make_opts` to be a string, not a list.

Signed-off-by: Major Hayden <major@redhat.com>