### PR TITLE
Use cookies for mboxes if specified

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -205,8 +205,11 @@ def cmd_merge(args):
                     state = {'patchwork_%02d' % idx[2]: patch}
                     update_state(args['rc'], state)
 
-                    # Merge the patch.
-                    ktree.merge_patchwork_patch(patch)
+                    # Merge the patch. Retrieve the Patchwork session cookie
+                    # first.
+                    session_id = get_state(args['rc'],
+                                           'patchwork_session_cookie')
+                    ktree.merge_patchwork_patch(patch, session_id)
 
                     # Increment the counter.
                     idx[2] += 1

--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -337,17 +337,18 @@ class KernelTree(object):
 
         return (SKT_SUCCESS, head)
 
-    def merge_patchwork_patch(self, uri):
+    def merge_patchwork_patch(self, uri, session_id=None):
         """
         Apply a patch from Patchwork (using git am)
 
         Args:
-            uri: URL of patch on a Patchwork instance.
+            uri:        URL of patch on a Patchwork instance.
+            session_id: Patchwork session cookie, in case login is required.
 
         Raises:
             PatchApplicationError in case the patch failed to apply.
         """
-        patch_content = get_patch_mbox(uri)
+        patch_content = get_patch_mbox(uri, session_id)
 
         logging.info("Applying %s", uri)
 

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -162,7 +162,10 @@ class Reporter(object):
 
         if self.cfg.get("patchworks"):
             for purl in self.cfg.get("patchworks"):
-                patch_mbox = get_patch_mbox(purl)
+                patch_mbox = get_patch_mbox(
+                    purl,
+                    self.cfg.get('patchwork_session_cookie')
+                )
                 patchname = get_patch_name(patch_mbox)
                 mergedata['patchwork'].append((purl, patchname))
 


### PR DESCRIPTION
Some Patchworks actually require login. Instead of handling usernames
and passwords as skt parameters, let's just use a pre-prepared netscape
cookie in the environment.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>