### PR TITLE
have kpet govern test-soaking enable/disable

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -316,15 +316,15 @@ class Reporter(object):
                     task_status = task_node.attrib['status']
                     task_url = ''
 
-                    # None or '1' or '0'
-                    task_soaking = self.soak_wrap.has_soaking(task_name)
+                    task_soaking = self.soak and self.soak_wrap.\
+                        is_soaking(task_node)
 
                     # Find git source, if any
                     fetch = task_node.find('fetch')
                     if fetch is not None:
                         task_url = fetch.attrib.get('url')
 
-                    if task_soaking is not None and task_result != 'Pass':
+                    if task_soaking and task_result != 'Pass':
                         # Don't add unsucessful tasks that are soaking.
                         continue
 

--- a/tests/assets/beaker_aborted_some.xml
+++ b/tests/assets/beaker_aborted_some.xml
@@ -10,6 +10,9 @@
         </log>
       </logs>
       <task name='/test/misc/machineinfo' result="Warn">
+        <params>
+          <param name="_WAIVED" value="true"/>
+        </params>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">
           </log>
@@ -29,6 +32,9 @@
         </log>
       </logs>
       <task name='/test/misc/machineinfo'>
+        <params>
+          <param name="_WAIVED" value="true"/>
+        </params>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">
           </log>
@@ -48,6 +54,9 @@
         </log>
       </logs>
       <task name='/test/misc/machineinfo'>
+        <params>
+          <param name="_WAIVED" value="true"/>
+        </params>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">
           </log>

--- a/tests/assets/beaker_recipe_set_fail_results.xml
+++ b/tests/assets/beaker_recipe_set_fail_results.xml
@@ -21,7 +21,11 @@
     <task name='/distribution/kpkginstall' result='Pass' status='Completed'>
       <fetch url="https://github.com/CKI-project/tests-beaker/archive/master.zip#distribution/kpkginstall"/>
     </task>
-    <task name='/test/we/ran' result='Fail' status='Completed'></task>
+    <task name='/test/we/ran' result='Fail' status='Completed'>
+      <params>
+        <param name="_WAIVED" value="true"/>
+      </params>
+    </task>
     <task name='/a/test/with/no/soak' result='Fail' status='Completed'></task>
   </recipe>
 </recipeSet>

--- a/tests/assets/beaker_results.xml
+++ b/tests/assets/beaker_results.xml
@@ -13,6 +13,9 @@
       </logs>
       <task name="/test/misc/boottest" result="Failed"><fetch url="kpkginstall"/></task>
       <task name='/test/misc/machineinfo' result="Failed">
+        <params>
+          <param name="_WAIVED" value="true"/>
+        </params>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">
           </log>

--- a/tests/assets/beaker_wait_pass.xml
+++ b/tests/assets/beaker_wait_pass.xml
@@ -49,7 +49,11 @@
       </logs>
 
       <task name='/distribution/install' result='Pass' />
-      <task name='/test/we/ran' result="Pass"/>
+      <task name='/test/we/ran' result="Pass">
+        <params>
+          <param name="_WAIVED" value="true"/>
+        </params>
+      </task>
 
     </recipe>
   </recipeSet>

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -57,7 +57,7 @@ def fake_cancel_pending_jobs(sself):
 
 
 def exec_on(myrunner, mock_jobsubmit, xml_asset_file, max_aborted,
-            alt_state=None):
+            alt_state=None, soak=False):
     """Simulate getting live results from Beaker.
     Feed skt/runner with an XML and change it after a couple of runs.
 
@@ -68,11 +68,12 @@ def exec_on(myrunner, mock_jobsubmit, xml_asset_file, max_aborted,
         max_aborted:    Maximum number of allowed aborted jobs. Abort the
                         whole stage if the number is reached.
         alt_state:      if set, represents a state to transition the job to
+        soak:           enable soaking
     Returns:
         BeakerRunner run() result
 
     """
-    # pylint: disable=W0613
+    # pylint: disable=W0613,too-many-arguments
     def fake_getresultstree(sself, taskspec):
         """Fakt getresultstree. Change state of last recipe on 3rd loop.
 
@@ -116,22 +117,11 @@ def exec_on(myrunner, mock_jobsubmit, xml_asset_file, max_aborted,
     # though beaker_pass_results.xml only needs one iteration
     myrunner.watchdelay = 0.01
 
-    result = myrunner.run(url, max_aborted, release, wait)
+    result = myrunner.run(url, max_aborted, release, wait, soak=soak)
 
     mock1.stop()
     mock2.stop()
     return result
-
-
-def fake_has_soaking(self, testname):
-    """ Fake function to mock has_soaking of SoakWrap.
-        Returns 1 for few selected tests.
-    """
-    # pylint: disable=unused-argument
-    if testname in ['/test/misc/machineinfo', '/test/we/ran']:
-        return 1
-
-    return None
 
 
 def fake_increase_test_runcount(self, testname, amount=1):


### PR DESCRIPTION
This patch moves information if the test is soaking to kpet-db instead of redis.
This is important fo QE to be able to control soaking enable/disable easily.
This also simplifies the way we use redis. 

<param name="_WAIVED" value="true"/>

inside every task's <params />.

Signed-off-by: Jakub Racek <jracek@redhat.com>