### PR TITLE
Fix broken dependency on pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     - TOX_ENV=py27,flake8,pylint
 install:
     # Install skt using pip to ensure dependencies are downloaded correctly.
-    - pip install .
+    - pip install .[dev]
     - pip install coveralls tox
 script:
     - tox -e $TOX_ENV

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,13 +12,8 @@ packages = find:
 # Parse the MANIFEST.in file and include those files, too.
 include_package_data = True
 # Let pip install dependencies automatically.
-install_requires = flake8
-                   jinja2>=2.10
-                   mock
+install_requires = jinja2>=2.10
                    defusedxml
-                   responses
-                   pycodestyle
-                   pylint
                    redis
                    requests
                    PyYAML
@@ -29,6 +24,10 @@ install_requires = flake8
 [options.extras_require]
 beaker = beaker-client
          python-krbV
+dev = pylint
+      flake8
+      mock
+      responses
 
 [options.entry_points]
 # Set up an executable 'skt' that calls the main() function in

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires = jinja2>=2.10
                    redis
                    requests
                    PyYAML
+                   enum34
 
 # The beaker-client package breaks some Python packaging rules and tries to
 # store content in the system /etc directory. This causes a Sandbox violation

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,12 @@ envlist =
 passenv = TRAVIS TRAVIS_*
 deps =
     coverage
-    mock
     coveralls
 commands =
     coverage run --branch --source=skt -m unittest discover tests
     coverage report -m
     coveralls
+install_command=pip install {opts} {packages} .[dev]
 
 [testenv:flake8]
 passenv = CI TRAVIS TRAVIS_*


### PR DESCRIPTION
Remove development dependencies from production creating a new extra option
called [dev].