### PR TITLE
fixup two result check bugs

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -392,7 +392,7 @@ class BeakerRunner(Runner):
             # everything is a test
             test_failure = True
 
-        elif self.err_on_failing_tasks(recipe, ['Failed']) is None:
+        elif self.err_on_failing_tasks(recipe, ['Fail']) is None:
             # A task that is waived failed. Waived tasks are
             # appended to the end of the recipe, so we should be able to
             # safely ignore this.
@@ -403,7 +403,9 @@ class BeakerRunner(Runner):
             test_list = self.get_recipe_test_list(recipe)
 
             for task in recipe.findall('task'):
-                if task.attrib.get('result') != 'Pass':
+                result = task.attrib.get('result')
+
+                if result != 'Pass' and result != 'Skip':
                     if task.attrib.get('name') in test_list:
                         test_failure = True
 

--- a/tests/assets/beaker_skip_and_fail.xml
+++ b/tests/assets/beaker_skip_and_fail.xml
@@ -1,0 +1,17 @@
+<job id="0001">
+  <whiteboard>
+    skt 4.17.0-rc1+ 1234567890.tar.gz [noavc] [noselinux]
+  </whiteboard>
+    <recipeSet>
+    <recipe result='Fail' status='Completed' id="123123">
+      <logs>
+        <log name='console.log' href="http://example.com/">
+          TEST RESULT
+        </log>
+      </logs>
+      <task name='/distribution/install' result='Pass' status="Completed"/>
+      <task name='/test/we/skipped' result="Skip" status="Completed"/>
+      <task name='/test/we/ran' result="Fail" status="Completed"/>
+    </recipe>
+  </recipeSet>
+</job>


### PR DESCRIPTION
1) check for 'Skip' task result

Even before __handle_test_fail() was introduced, the original code would
happily report any state different than 'Pass' as a test_failure,
leading to aborting that job.

2) a typo 'Failed' -> 'Fail'

err_on_failing_tasks() is there to handle waiving. It should check for
'Fail' not 'Failed' result of tasks.
This doesn't impact the code, because we don't yet use XMLs with _WAIVED
attribute and the failure is caught by a follow-up check (the code
adjusted for bugfix 1).

This patch contains testcase for bugfix 1) that I've seen and reported.

Signed-off-by: Jakub Racek <jracek@redhat.com>