### PR TITLE
Store Beaker results XML

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -179,10 +179,17 @@ class BeakerRunner(Runner):
         Returns:
             etree node representing the results.
         """
-        args = ["bkr", "job-results", taskspec]
+        args = ["bkr", "job-results", "--prettyxml", taskspec]
 
         bkr = subprocess.Popen(args, stdout=subprocess.PIPE)
         (stdout, _) = bkr.communicate()
+
+        # Write the Beaker results locally so they could be stored as an
+        # artifact.
+        results_filename = 'beaker-results-{}.xml'.format(taskspec)
+        with open(results_filename, 'wb') as fileh:
+            fileh.write(stdout)
+
         return fromstring(stdout)
 
     def __forget_taskspec(self, taskspec):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -364,8 +364,10 @@ class TestRunner(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = (test_xml, '')
 
         self.myrunner._BeakerRunner__add_to_watchlist(j_jobid)
-        mock_popen.assert_called_once_with(["bkr", "job-results", j_jobid],
-                                           stdout=subprocess.PIPE)
+        mock_popen.assert_called_once_with(
+            ["bkr", "job-results", "--prettyxml", j_jobid],
+            stdout=subprocess.PIPE
+        )
 
         # test that whiteboard was parsed OK
         self.assertEqual(self.myrunner.whiteboard, 'yeah-that-whiteboard')


### PR DESCRIPTION
When downloading results from beaker, download them in a pretty format
and store them to the disk. This makes it possible to read the XML as
an artifact without lots of requests to Beaker for additional information
later on in the pipeline.

Signed-off-by: Major Hayden <major@redhat.com>