### PR TITLE
Do not report any waived tasks

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -324,8 +324,8 @@ class Reporter(object):
                     if fetch is not None:
                         task_url = fetch.attrib.get('url')
 
-                    if is_task_waived and task_result != 'Pass':
-                        # Don't add unsucessful tasks that are waived.
+                    if is_task_waived:
+                        # Don't add tasks that are waived.
                         continue
 
                     if task_result == 'Pass':


### PR DESCRIPTION
Waived tasks should not appear in the normal report at all without being
clearly marked as "waived" (ignored), so developers don't expect their
failure to affect the overall result.