### PR TITLE
fixup catching panics

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -239,6 +239,9 @@ class BeakerRunner(Runner):
                 if self.waiving and self.waiving_wrap.is_task_waived(task):
                     continue
                 else:
+                    if result == 'Panic':
+                        return SKT_FAIL
+
                     if status == 'Aborted':
                         return SKT_ERROR
 


### PR DESCRIPTION
There's a missing case in the code. Panic result is always SKT_FAIL,
regardless of status.

Signed-off-by: Jakub Racek <jracek@redhat.com>