### PR TITLE
Making ppcs distiguishable

### DIFF
--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -193,8 +193,8 @@ class KernelBuilder(object):
         """Determine the build architecture for the kernel build."""
         # pylint: disable=no-self-use
         # Detect cross-compiling via the ARCH= environment variable
-        if 'ARCH' in os.environ:
-            return os.environ['ARCH']
+        if 'ARCH_CONFIG' in os.environ:
+            return os.environ['ARCH_CONFIG']
 
         return platform.machine()
 

--- a/tests/test_kernelbuilder.py
+++ b/tests/test_kernelbuilder.py
@@ -108,9 +108,9 @@ class KBuilderTest(unittest.TestCase):
             )
 
     def test_get_build_arch(self):
-        """Ensure __get_build_arch() returns the ARCH env variable."""
+        """Ensure __get_build_arch() returns the ARCH_CONFIG env variable."""
         # pylint: disable=W0212,E1101
-        os.environ['ARCH'] = 's390x'
+        os.environ['ARCH_CONFIG'] = 's390x'
         result = self.kbuilder._KernelBuilder__get_build_arch()
 
         self.assertEqual('s390x', result)


### PR DESCRIPTION
Adding a simple "(le)" to the name if the ARCH_CONFIG variable ends with "le".