### PR TITLE
v2: Add support for the distribution of kABI-related files inside of the kernel tarball

### DIFF
--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -516,6 +516,12 @@ class KernelBuilder(object):
             + kernel_build_argv
         )
 
+        # Generate kABI whitelist information for RHEL kernels.
+        if self.cfgtype == 'rh-configs':
+            if not os.path.exists("/usr/libexec/platform-python"):
+                raise Exception("Failed to find platform-python.")
+            self.__make_redhat_kabi()
+
         # Compile the kernel.
         returncode = self.run_multipipe(kernel_build_argv)
 
@@ -534,8 +540,16 @@ class KernelBuilder(object):
                 ' '.join(kernel_build_argv)
             )
 
+        # Find extras to be distributed alongside the kernel.
+        extras = []
+        extras += self.find_extras('redhat/kabi/kabi-current',
+                                   followlinks=True)
+        extras += self.find_extras('redhat/rh-priv/kabi/kabi-current',
+                                   followlinks=True)
+
         if 'tar' in self.make_target:
             package_path = self.handle_tarball()
+            self.append_to_tarball(package_path, extras)
 
         if 'rpm' in self.make_target:
             package_path = self.handle_rpm()

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -189,6 +189,20 @@ class KernelBuilder(object):
         logging.info("building %s: %s", self.cfgtype, args)
         self.run_multipipe(args)
 
+    def __make_redhat_kabi(self):
+        """
+        Make kABI whitelists files. Invoke the target separately and with
+        --always-make to make sure kABI whitelists are regenerated.
+        """
+        args = self.make_argv_base + ['--always-make', 'rh-kabi']
+        logging.info("building Red Hat kABI whitelists: %s", args)
+        retcode = self.run_multipipe(args)
+        if retcode != 0:
+            raise subprocess.CalledProcessError(
+                retcode,
+                ' '.join(args)
+            )
+
     def __get_build_arch(self):
         """Determine the build architecture for the kernel build."""
         # pylint: disable=no-self-use


### PR DESCRIPTION
Introduce the support for appending to the generated tarball.

Changes in v2:
 - fixed Travis/flake8 issues with 80 line intend and whitespaces around `[` `]`, no more `flake8` errors encountered;
```
./skt/kernelbuilder.py:350:80: E501 line too long (80 > 79 characters)
./skt/kernelbuilder.py:351:80: E501 line too long (80 > 79 characters)
./skt/kernelbuilder.py:425:28: E201 whitespace after '['
./skt/kernelbuilder.py:425:50: E202 whitespace before ']'
./skt/kernelbuilder.py:449:26: E201 whitespace after '['
./skt/kernelbuilder.py:449:46: E202 whitespace before ']'
```
```
$ flake8 --show-source ./kernelbuilder.py
$
```