### PR TITLE
Revert "allow permissive makefile target"

### DIFF
--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -108,10 +108,9 @@ class KernelBuilder(object):
 
     def __prepare_kernel_config(self):
         """Prepare the kernel config for the compile."""
-        if self.cfgtype == 'rh-configs' or self.cfgtype == \
-                'rh-configs-permissive':
+        if self.cfgtype == 'rh-configs':
             # Build Red Hat configs and copy the correct one into place
-            self.__make_redhat_config(self.cfgtype)
+            self.__make_redhat_config()
         elif self.cfgtype in ['tinyconfig', 'allyesconfig', 'allmodconfig']:
             # Use the cfgtype provided with the kernel's Makefile.
             self.__make_config()
@@ -147,14 +146,9 @@ class KernelBuilder(object):
 
         self._ready = 1
 
-    def __make_redhat_config(self, target):
-        """ Prepare the Red Hat kernel config files.
-
-            Args:
-                target: makefile target, usually 'rh-configs' or
-                'rh-configs-permissive'
-        """
-        args = self.make_argv_base + [target]
+    def __make_redhat_config(self):
+        """Prepare the Red Hat kernel config files."""
+        args = self.make_argv_base + ['rh-configs']
         logging.info("building Red Hat configs: %s", args)
 
         # Unset CROSS_COMPILE because rh-configs doesn't handle the cross

--- a/tests/test_kernelbuilder.py
+++ b/tests/test_kernelbuilder.py
@@ -211,7 +211,7 @@ class KBuilderTest(unittest.TestCase):
         mock_glob.return_value = []
         self.kbuilder.rh_configs_glob = "redhat/configs/kernel-*-x86_64.config"
         with self.assertRaises(SystemExit):
-            self.kbuilder._KernelBuilder__make_redhat_config('rh-configs')
+            self.kbuilder._KernelBuilder__make_redhat_config()
 
         mock_info.assert_called_once()
         mock_err.assert_called_once()


### PR DESCRIPTION
This reverts commit 82d2f7b0304bafad3fde2d25fdcf3b66542536ca.

The idea of rh-configs-permissive make target was abandoned.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>