### PR TITLE
Only forget the taskspec after resubmission

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -398,7 +398,6 @@ class BeakerRunner(Runner):
         logging.warning('%s from %s aborted!',
                         recipe_id,
                         recipe_set_id)
-        self.__forget_taskspec(recipe_set_id)
         self.aborted_count += 1
 
         if self.aborted_count < self.max_aborted:
@@ -407,6 +406,8 @@ class BeakerRunner(Runner):
             newjob = self.__recipe_set_to_job(root)
             newjobid = self.__jobsubmit(etree.tostring(newjob))
             self.__add_to_watchlist(newjobid)
+
+        self.__forget_taskspec(recipe_set_id)
 
     def __handle_test_fail(self, recipe):
         # Something in the recipe set really reported failure


### PR DESCRIPTION
If we remove the recipe set and job from watchlist first, we fail to
find them in get_recipeset_group. This means that all the jobs will be
without the orginal group, because we don't know what job to query to
find it.

Move taskspec deletion after (potential) resubmission to fix this.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>