### PR TITLE
Add release tag to localversion

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -264,7 +264,8 @@ def cmd_build(args):
         enable_debuginfo=args.get('enable_debuginfo'),
         rh_configs_glob=args.get('rh_configs_glob'),
         make_target=args.get('make_target'),
-        localversion=args.get('localversion')
+        localversion=args.get('localversion'),
+        tag=get_state(args['rc'], 'tag')
     )
 
     # Clean the kernel source with 'make mrproper' if requested.
@@ -345,19 +346,7 @@ def cmd_build(args):
         update_state(args['rc'], state)
 
         # Get the kernel version string.
-        tag = get_state(args['rc'], 'tag')
         krelease = builder.getrelease()
-
-        if tag and tag != "":
-            index = krelease.rfind('.')
-            if '-' in krelease:
-                # In case of 5.1.0-rc1.cki
-                # (removes the -rc1 since that's in the tag already)
-                dash = krelease.rfind('-')
-                krelease = krelease[:dash] + krelease[index:]
-                index = krelease.rfind('.')
-
-            krelease = krelease[:index] + "-" + tag + krelease[index:]
 
         state = {'krelease': krelease}
         update_state(args['rc'], state)

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -35,7 +35,7 @@ class KernelBuilder(object):
     def __init__(self, source_dir, basecfg, cfgtype=None,
                  extra_make_args=None, enable_debuginfo=False,
                  rh_configs_glob=None, localversion=None,
-                 make_target=None):
+                 make_target=None, tag=""):
         self.source_dir = source_dir
         self.basecfg = basecfg
         self.cfgtype = cfgtype if cfgtype is not None else "olddefconfig"
@@ -58,6 +58,7 @@ class KernelBuilder(object):
         self.cross_compiler_prefix = self.__get_cross_compiler_prefix()
         self.rh_configs_glob = rh_configs_glob
         self.localversion = localversion
+        self.tag = tag
 
         # Handle the make target provided and select the correct arguments
         # for make based on the target.
@@ -141,7 +142,7 @@ class KernelBuilder(object):
         self.__adjust_config_option(
             'set-str',
             'LOCALVERSION',
-            '.{}'.format(self.localversion)
+            '-{}.{}'.format(self.tag, self.localversion)
         )
 
         self._ready = 1


### PR DESCRIPTION
Adding the tag to config with localversion so that 'make kernelrelease' now has the tag as well

The krelease variable is taken from the end of the build which prints the same value so there's no longer a need to add it later.