### PR TITLE
fix configparser-use breakage

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -226,7 +226,7 @@ def load_config(args):
     """
     # NOTE(mhayden): The shell should do any tilde expansions on the path
     # before the rc path is provided to Python.
-    config_parser = configparser.ConfigParser()
+    config_parser = configparser.RawConfigParser()
     config_parser.read(os.path.abspath(args.rc))
 
     cfg = vars(args)


### PR DESCRIPTION
Don't use ConfigParser, use RawConfigParser instead because we don't
want variable substitution.

Signed-off-by: Jakub Racek <jracek@redhat.com>