### PR TITLE
update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for skt
 
+## June 2019
+
+* All commands except for `skt run` dropped; this has been replaced with
+  GitLab pipeline yaml. SKT serves only to submit and watch Beaker jobs.
+
 ## June 2018
 
 * Arguments for `skt merge` should now be used multiple times instead of

--- a/README.md
+++ b/README.md
@@ -12,27 +12,22 @@ Dependencies
 
 Install dependencies needed for running skt like this:
 
-    sudo dnf install -y python2 beaker-client
-
-Dependencies needed to build kernels:
-
-    sudo dnf install -y bison flex dnf-plugins-core
-    sudo dnf builddep -y kernel-`uname -r`
+    sudo dnf install -y python3 beaker-client
 
 Extra dependencies needed for running the testsuite:
 
-    sudo dnf install -y python2-mock PyYAML
+    sudo dnf install -y python3-mock
 
 Run tests
 ---------
 
 To run all tests execute:
 
-    python -m unittest discover tests
+    python3 -m unittest discover tests
 
 To run some specific tests, you can execute a specific test like this:
 
-    python -m unittest tests.test_runner
+    python3 -m unittest tests.test_runner
 
 
 Installation
@@ -62,11 +57,11 @@ summary of particular command's options and arguments, run `skt <COMMAND>
 --help`, where `<COMMAND>` would be the command of interest.
 
 Most of command-line options can also be read by `skt` from its configuration
-file, which is `~/.sktrc` by default, but can also be specified using the
-global `--rc` command-line option. However, there are some command-line
-options which cannot be stored in the configuration file, and there are some
-options read from the configuration file by some `skt` commands, which cannot
-be passed via the command line. Some of the latter are required for operation.
+file, which is specified using the global `--rc` command-line option. However,
+there are some command-line options which cannot be stored in the configuration
+file, and there are some options read from the configuration file by some `skt`
+commands, which cannot be passed via the command line. Some of the latter are
+required for operation.
 
 Most `skt` commands can write their state to the configuration file as they
 work, so that the other commands can take the workflow task over from them.

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ include_package_data = True
 install_requires = jinja2>=2.10
                    defusedxml
                    requests
-                   PyYAML
                    enum34
 
 # The beaker-client package breaks some Python packaging rules and tries to


### PR DESCRIPTION
Drop references to Python2 and to unused libraries (yaml).
Drop references to ~/.sktrc.
Drop references to building kernels.

Adjust CHANGELOG.md.

Signed-off-by: Jakub Racek <jracek@redhat.com>