### PR TITLE
Switch to using CKI_WAIVED task parameter

### DIFF
--- a/skt/misc.py
+++ b/skt/misc.py
@@ -40,7 +40,7 @@ class WaivingWrap(object):
         is_task_waived = False
         for param in task.findall('.//param'):
             try:
-                if param.attrib.get('name').lower() == '_waived' and \
+                if param.attrib.get('name').lower() == 'cki_waived' and \
                         param.attrib.get('value').lower() == 'true':
                     is_task_waived = True
                     break

--- a/tests/assets/beaker_aborted_some.xml
+++ b/tests/assets/beaker_aborted_some.xml
@@ -11,7 +11,7 @@
       </logs>
       <task name='/test/misc/machineinfo' result="Warn">
         <params>
-          <param name="_WAIVED" value="true"/>
+          <param name="CKI_WAIVED" value="true"/>
         </params>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">
@@ -33,7 +33,7 @@
       </logs>
       <task name='/test/misc/machineinfo'>
         <params>
-          <param name="_WAIVED" value="true"/>
+          <param name="CKI_WAIVED" value="true"/>
         </params>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">
@@ -55,7 +55,7 @@
       </logs>
       <task name='/test/misc/machineinfo'>
         <params>
-          <param name="_WAIVED" value="true"/>
+          <param name="CKI_WAIVED" value="true"/>
         </params>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">

--- a/tests/assets/beaker_recipe_set_fail_results.xml
+++ b/tests/assets/beaker_recipe_set_fail_results.xml
@@ -23,12 +23,12 @@
     </task>
     <task name='/a/failed/waived/test' result='Fail' status='Completed'>
       <params>
-        <param name="_WAIVED" value="true"/>
+        <param name="CKI_WAIVED" value="true"/>
       </params>
     </task>
     <task name='/a/passed/waived/test' result='Pass' status='Completed'>
       <params>
-        <param name="_WAIVED" value="true"/>
+        <param name="CKI_WAIVED" value="true"/>
       </params>
     </task>
     <task name='/a/test/with/no/waive' result='Fail' status='Completed'></task>

--- a/tests/assets/beaker_results.xml
+++ b/tests/assets/beaker_results.xml
@@ -13,12 +13,12 @@
       </logs>
       <task name="/test/misc/boottest" result="Fail">
                 <params>
-          <param name="_WAIVED" value="true"/>
+          <param name="CKI_WAIVED" value="true"/>
         </params>
         <fetch url="kpkginstall"/></task>
       <task name='/test/misc/machineinfo' result="Fail">
         <params>
-          <param name="_WAIVED" value="true"/>
+          <param name="CKI_WAIVED" value="true"/>
         </params>
         <logs>
           <log name='machinedesc.log' href="http://example.com/machinedesc.log">

--- a/tests/assets/beaker_wait_pass.xml
+++ b/tests/assets/beaker_wait_pass.xml
@@ -51,7 +51,7 @@
       <task name='/distribution/install' result='Pass' />
       <task name='/test/we/ran' result="Pass">
         <params>
-          <param name="_WAIVED" value="true"/>
+          <param name="CKI_WAIVED" value="true"/>
         </params>
       </task>
 


### PR DESCRIPTION
We've renamed the `_WAIVED` task parameter to `CKI_WAIVED` everywhere, but in skt. So, skt considers all waived tests as unwaived. This does the rename in skt as well and fixes the problem.