### PR TITLE
Return different code if booting failed

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -101,7 +101,6 @@ def cmd_run(config_set):
 
     config_set['jobs'] = ' '.join(runner.job_to_recipe_set_map.keys())
 
-
     save_state(config_set, {'retcode': retcode})
 
     return retcode

--- a/skt/misc.py
+++ b/skt/misc.py
@@ -19,6 +19,7 @@ import logging
 SKT_SUCCESS = 0
 SKT_FAIL = 1
 SKT_ERROR = 2
+SKT_BOOT = 3
 
 LOGGER = logging.getLogger()
 

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -24,7 +24,7 @@ import time
 from defusedxml.ElementTree import fromstring
 from defusedxml.ElementTree import tostring
 
-from skt.misc import SKT_SUCCESS, SKT_FAIL, SKT_ERROR
+from skt.misc import SKT_SUCCESS, SKT_FAIL, SKT_ERROR, SKT_BOOT
 from skt.misc import WaivingWrap
 
 
@@ -239,7 +239,7 @@ class BeakerRunner:
 
         """
         if self._not_booting(recipe_result):
-            return SKT_FAIL
+            return SKT_BOOT
 
         prev_task_panicked_and_waived = False
         for task in recipe_result.findall('task'):
@@ -648,6 +648,7 @@ class BeakerRunner:
                    SKT_FAIL if testing failed
                    SKT_ERROR in case of infrastructure error (exceptions are
                                                               logged)
+                   SKT_BOOT if the boot test failed
         """
         # pylint: disable=too-many-arguments
         ret = SKT_SUCCESS

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -149,8 +149,9 @@ class TestRunner(unittest.TestCase):
         # pylint: disable=W0212,E1101
         j_jobid = 'J:123'
         setid = '456'
-        test_xml = bytearray("""<xml><whiteboard>yeah-that-whiteboard</whiteboard>
-        <recipeSet id="{}" /></xml>""".format(setid), 'utf-8')
+        test_xml = bytearray(
+            """<xml><whiteboard>yeah-that-whiteboard</whiteboard>
+            <recipeSet id="{}" /></xml>""".format(setid), 'utf-8')
 
         mock_popen.return_value.returncode = 0
         mock_popen.return_value.communicate.return_value = (test_xml, '')
@@ -350,8 +351,9 @@ class TestRunner(unittest.TestCase):
         j_jobid = 'J:123'
         setid = '456'
         s_setid = 'RS:{}'.format(setid)
-        test_xml = bytearray("""<xml><whiteboard>yeah-that-whiteboard</whiteboard>
-        <recipeSet id="{}" /></xml>""".format(setid), 'utf-8')
+        test_xml = bytearray(
+            """<xml><whiteboard>yeah-that-whiteboard</whiteboard>
+            <recipeSet id="{}" /></xml>""".format(setid), 'utf-8')
 
         mock_popen.return_value.returncode = 0
         mock_popen.return_value.communicate.return_value = (test_xml, '')


### PR DESCRIPTION
The warn/aborted task result is the same as for infrastructure failures.
Instead of having to go through all the pain of differentiating between
failed boot and general aborted tasks in the reporter, we should simply
pass this information clearly from skt as it already does this check.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>