### PR TITLE
fix status/result typo

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -258,7 +258,7 @@ class BeakerRunner:
 
                     continue
                 else:
-                    if result == 'Aborted' and prev_task_panicked_and_waived:
+                    if status == 'Aborted' and prev_task_panicked_and_waived:
                         return SKT_SUCCESS
 
                     if result == 'Panic':


### PR DESCRIPTION
There is no such result as 'Aborted', but there is status 'Aborted'.

Signed-off-by: Jakub Racek <jracek@redhat.com>