### PR TITLE
improve retcode checking

### DIFF
--- a/skt/misc.py
+++ b/skt/misc.py
@@ -24,28 +24,21 @@ SKT_BOOT = 3
 LOGGER = logging.getLogger()
 
 
-class WaivingWrap(object):
-    """ This handles getting/updating waived data and simplifies mocking."""
-    # pylint: disable=too-few-public-methods
-    def __init__(self, waiving):
-        self.waiving = waiving
+def is_task_waived(task):
+    """ Check XML param to see if the test is waived.
+        Args:
+            task: xml node
 
-    @classmethod
-    def is_task_waived(cls, task):
-        """ Check XML param to see if the test is waived.
-            Args:
-                task: xml node
+        Returns: True if test is waived, otherwise False
+    """
+    is_task_waived_val = False
+    for param in task.findall('.//param'):
+        try:
+            if param.attrib.get('name').lower() == 'cki_waived' and \
+                    param.attrib.get('value').lower() == 'true':
+                is_task_waived_val = True
+                break
+        except ValueError:
+            pass
 
-            Returns: True if test is waived, otherwise False
-        """
-        is_task_waived = False
-        for param in task.findall('.//param'):
-            try:
-                if param.attrib.get('name').lower() == 'cki_waived' and \
-                        param.attrib.get('value').lower() == 'true':
-                    is_task_waived = True
-                    break
-            except ValueError:
-                pass
-
-        return is_task_waived
+    return is_task_waived_val

--- a/tests/assets/beaker_fail_results.xml
+++ b/tests/assets/beaker_fail_results.xml
@@ -1,5 +1,5 @@
 <recipeSet>
-  <recipe result='Fail' status='Completed'>
+  <recipe id="1234" result='Fail' status='Completed'>
     <logs>
       <log name='console.log' href="http://example.com/">
         TEST RESULT

--- a/tests/assets/beaker_recipe_set_results.xml
+++ b/tests/assets/beaker_recipe_set_results.xml
@@ -1,5 +1,5 @@
 <recipeSet id="1234">
-  <recipe system='machine.beaker.org' result='Pass' status='Completed'>
+  <recipe id="5678" system='machine.beaker.org' result='Pass' status='Completed'>
     <hostRequires>
       <and>
         <arch op="=" value="x86_64"/>
@@ -21,6 +21,6 @@
     <task name='/distribution/kpkginstall' result='Pass' status='Completed'>
       <fetch url="https://github.com/CKI-project/tests-beaker/archive/master.zip#distribution/kpkginstall"/>
     </task>
-    <task name='/test/we/ran' result='Pass' status='Completed'></task>
+    <task name='/test/we/ran' result='Pass' status='Completed' />
   </recipe>
 </recipeSet>

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -301,10 +301,12 @@ class TestRunner(unittest.TestCase):
         expected_xml = self.test_xml.replace("##ARCH##", "s390x")
         self.assertEqual(result, expected_xml)
 
+    @mock.patch('subprocess.Popen')
     @mock.patch('logging.error')
     @mock.patch('subprocess.call')
     @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
-    def test_cleanup_called(self, mock_jobsubmit, mock_call, mock_log_err):
+    def test_cleanup_called(self, mock_jobsubmit, mock_call, mock_log_err,
+                            mock_popen):
         """Ensure BeakerRunner.signal_handler works."""
         # pylint: disable=W0613
         url = "http://machine1.example.com/builds/1234567890.tar.gz"
@@ -313,6 +315,8 @@ class TestRunner(unittest.TestCase):
         mock_jobsubmit.return_value = "J:0001"
 
         mock_call.return_value = 0
+
+        mock_popen.return_value = 0
 
         signal.signal(signal.SIGINT, self.myrunner.signal_handler)
         signal.signal(signal.SIGTERM, self.myrunner.signal_handler)
@@ -329,10 +333,12 @@ class TestRunner(unittest.TestCase):
 
         self.assertTrue(self.myrunner.cleanup_done)
 
+    @mock.patch('subprocess.Popen')
     @mock.patch('logging.error')
     @mock.patch('subprocess.call')
     @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
-    def test_cleanup_called2(self, mock_jobsubmit, mock_call, mock_log_err):
+    def test_cleanup_called2(self, mock_jobsubmit, mock_call, mock_log_err,
+                             mock_popen):
         """Ensure BeakerRunner cleanup isn't called twice."""
         # pylint: disable=W0613
 
@@ -342,6 +348,7 @@ class TestRunner(unittest.TestCase):
         mock_jobsubmit.return_value = "J:0001"
 
         mock_call.return_value = 0
+        mock_popen.return_value = 0
 
         signal.signal(signal.SIGINT, self.myrunner.signal_handler)
         signal.signal(signal.SIGTERM, self.myrunner.signal_handler)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -143,10 +143,11 @@ class TestRunner(unittest.TestCase):
             mock_popen.assert_called_once_with(args, stdin=subprocess.PIPE,
                                                stdout=subprocess.PIPE)
 
+    @mock.patch('builtins.open', create=True)
     @mock.patch('subprocess.Popen')
-    def test_cancel_pending_jobs(self, mock_popen):
+    def test_cancel_pending_jobs(self, mock_popen, mock_open):
         """ Ensure cancel_pending_jobs works."""
-        # pylint: disable=W0212,E1101
+        # pylint: disable=W0212,E1101,W0613
         j_jobid = 'J:123'
         setid = '456'
         test_xml = bytearray(
@@ -301,14 +302,15 @@ class TestRunner(unittest.TestCase):
         expected_xml = self.test_xml.replace("##ARCH##", "s390x")
         self.assertEqual(result, expected_xml)
 
+    @mock.patch('builtins.open', create=True)
     @mock.patch('subprocess.Popen')
     @mock.patch('logging.error')
     @mock.patch('subprocess.call')
     @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
     def test_cleanup_called(self, mock_jobsubmit, mock_call, mock_log_err,
-                            mock_popen):
+                            mock_popen, mock_open):
         """Ensure BeakerRunner.signal_handler works."""
-        # pylint: disable=W0613
+        # pylint: disable=W0613,R0913
         url = "http://machine1.example.com/builds/1234567890.tar.gz"
         release = "4.17.0-rc1"
         wait = True
@@ -333,14 +335,15 @@ class TestRunner(unittest.TestCase):
 
         self.assertTrue(self.myrunner.cleanup_done)
 
+    @mock.patch('builtins.open', create=True)
     @mock.patch('subprocess.Popen')
     @mock.patch('logging.error')
     @mock.patch('subprocess.call')
     @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
     def test_cleanup_called2(self, mock_jobsubmit, mock_call, mock_log_err,
-                             mock_popen):
+                             mock_popen, mock_open):
         """Ensure BeakerRunner cleanup isn't called twice."""
-        # pylint: disable=W0613
+        # pylint: disable=W0613,R0913
 
         url = "http://machine1.example.com/builds/1234567890.tar.gz"
         release = "4.17.0-rc1"
@@ -367,10 +370,11 @@ class TestRunner(unittest.TestCase):
 
         self.assertFalse(mock_call.called)
 
+    @mock.patch('builtins.open', create=True)
     @mock.patch('subprocess.Popen')
-    def test_add_to_watchlist(self, mock_popen):
+    def test_add_to_watchlist(self, mock_popen, mock_open):
         """Ensure __add_to_watchlist() works."""
-        # pylint: disable=W0212,E1101
+        # pylint: disable=W0212,E1101,W0613
         j_jobid = 'J:123'
         setid = '456'
         s_setid = 'RS:{}'.format(setid)
@@ -400,9 +404,11 @@ class TestRunner(unittest.TestCase):
         # test that no recipes completed
         self.assertEqual(self.myrunner.completed_recipes[s_setid], set())
 
+    @mock.patch('builtins.open', create=True)
     @mock.patch('subprocess.Popen')
-    def test_getresultstree(self, mock_popen):
+    def test_getresultstree(self, mock_popen, mock_open):
         """Ensure getresultstree() works."""
+        # pylint: disable=W0613
         test_xml = bytearray("<xml><test>TEST</test></xml>", 'utf-8')
         mock_popen.return_value.returncode = 0
         mock_popen.return_value.communicate.return_value = (test_xml, '')


### PR DESCRIPTION
In order to prepare skt for multirecipe/recipeset handling, we should
improve retcode checking.
This patch should mean no functional changes, but should make things
easier to read and manage.

Signed-off-by: Jakub Racek <jracek@redhat.com>