### PR TITLE
bugfix: typo in results checking

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -89,7 +89,7 @@ result_condition_checks = [
 
     # A non-waived tasked aborted, return SKT_ERROR, possible
     # infra issue.
-    ConditionCheck(SKT_FAIL, result='Warn',  waived=False, status='Aborted'),
+    ConditionCheck(SKT_ERROR, result='Warn',  waived=False, status='Aborted'),
 
     # The rest of the fall-through conditions.
     ConditionCheck(SKT_FAIL, result='Warn', waived=False),


### PR DESCRIPTION
Nice typo, my other self. The comment says it correctly, but the
condition doesn't. At least the result evaluation is much more readable
today.

Signed-off-by: Jakub Racek <jracek@redhat.com>