### PR TITLE
remove misleading message

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -445,10 +445,6 @@ class BeakerRunner:
         # skt is being terminated, cancel its jobs
         # NOTE(mhayden): Per ticket #1140, Beaker jobs must continue to run
         # when a timeout is reached and skt is killed in the GitLab pipeline.
-        logging.info(
-            "Timeout reached but skt is not killing Beaker jobs (see #1140)"
-        )
-        # self.cancel_pending_jobs()
 
         self.cleanup_done = True
 


### PR DESCRIPTION
When cleanup_handler() is called, it doesn't automatically mean that SKT
got terminated because of timeout.
We could add extra code to detect this, but a simpler solution is to
just remove the deadcode/comment and the misleading message.

Signed-off-by: Jakub Racek <jracek@redhat.com>