### PR TITLE
don't discard recipeset when we ran out of retries

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -496,7 +496,10 @@ class BeakerRunner:
             newjobid = self.__jobsubmit(tostring(newjob))
             self.__add_to_watchlist(newjobid)
 
-        self.__forget_taskspec(recipe_set_id)
+            # discard aborted result only if we have attempts left
+            self.__forget_taskspec(recipe_set_id)
+        else:
+            self.watchlist.discard(recipe_set_id)
 
     def __handle_test_fail(self, recipe, recipe_id):
         # Something in the recipe set really reported failure


### PR DESCRIPTION
The logic in SKT watchloop is convoluted and needs to be rewritten
eventually. For now, let's fix this bug. Whenever we do a next
abort-retry, we also delete the taskspec from both watchlist and from
results. This makes sense when we allow more retries, but when we run
out, we must keep the last result to be detected as infrastructure
issue.
The code as-is used to work only because when we run out of
abort-retries, we cancel remaining jobs and detect a cancelled run.
However, if we have only 1 job running, this doesn't work.

Signed-off-by: Jakub Racek <jracek@redhat.com>