### PR TITLE
retry bkr job-submit on specific stderr data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2017-2019 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2017-2019 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.

--- a/skt/misc.py
+++ b/skt/misc.py
@@ -15,6 +15,7 @@
 import logging
 import subprocess
 
+from skt.retrying import retrying_on_exception
 # SKT Result
 SKT_SUCCESS = 0
 SKT_FAIL = 1
@@ -22,6 +23,40 @@ SKT_ERROR = 2
 SKT_BOOT = 3
 
 LOGGER = logging.getLogger()
+
+
+@retrying_on_exception(RuntimeError)
+def retry_safe_popen(err_exc_strings, *args, stdin_data=None, **kwargs):
+    """ Call safe_popen with *args, stdin_data=None, **kwargs provided,
+        If stderr stream is present and contains any string in err_exc_strings
+        list, then the process call is done again with retry after 3 seconds
+        (see retrying_on_exception decorator). Log commands retry and allow 3
+        retries max. Also log if last command failed and we gave up. The
+        program execution is not terminated / no exception is raised on last
+        failure.
+
+        Args:
+            err_exc_strings: a list of strings; if any is present in stderr,
+                             retry the command
+            args:            arguments to pass to Popen
+            stdin_data:      None or str, use None when you don't want to pass
+                             string data to stdin
+            kwargs:          keyword arguments to pass to Popen
+        Returns:
+            tuple (stdout, stderr, returncode) where
+                stdout is a string
+                stderr is a string
+                returncode is an integer
+    """
+    stdout, stderr, returncode = safe_popen(*args, stdin_data=stdin_data,
+                                            **kwargs)
+
+    for err_str in err_exc_strings:
+        if stderr and err_str in stderr:
+            logging.warning(stderr.strip())
+            raise RuntimeError
+
+    return stdout, stderr, returncode
 
 
 def safe_popen(*args, stdin_data=None, **kwargs):

--- a/skt/misc.py
+++ b/skt/misc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2017-2019 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.

--- a/skt/retrying.py
+++ b/skt/retrying.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Retrying decorator to retry method/function several times."""
+
+import time
+import logging
+
+
+def retrying_on_exception(exception, retries=3, initial_delay=3):
+    """Decorate method/function to be retried on exception after initial_delay.
+
+    Do retries based on how many were set. The wait delay before next
+    attempt is increased by initial_delay each time.
+
+    Arguments:
+        exception:     a type of exception to catch, e.g. RuntimeError
+        retries:       max. number of times the decorated method will be run
+        initial_delay: a number of seconds to wait after first exception;
+                       the total number of seconds we wait is increased by this
+                       amount after each retry
+    """
+    def wrapper(function):
+        def wrapped(*args, **kwargs):
+            wrapped.failed_count = 0
+            wrapped.retries = retries
+
+            delay = 0
+            for _ in range(0, retries):
+                delay += initial_delay
+
+                try:
+                    return function(*args, **kwargs)
+                except exception:
+                    wrapped.failed_count += 1
+
+                    if wrapped.failed_count != retries:
+                        logging.warning('RETRY func(%s), delaying for %ds',
+                                        ', '.join(list(*args)), delay)
+                        time.sleep(delay)
+                    else:
+                        logging.warning('RETRY giving up on func(%s)',
+                                        ', '.join(list(*args)))
+                        # don't sleep on last attempt, there's no point;
+                        # instead raise exception
+                        raise
+
+        return wrapped
+
+    return wrapper

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2017-2019 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2018-2019 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General Public
 # License v.2 or later.

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2018-2019 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General Public
 # License v.2 or later.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2018-2019 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General Public
 # License v.2 or later.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -104,7 +104,8 @@ class TestRunner(unittest.TestCase):
         self.myrunner._BeakerRunner__jobsubmit('<xml />')
 
         mock_popen.assert_called_once_with(args, stdin=subprocess.PIPE,
-                                           stdout=subprocess.PIPE)
+                                           stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE)
 
     @mock.patch('subprocess.Popen')
     def test_jobsubmit_exc(self, mock_popen):


### PR DESCRIPTION
This patch adds a retry-decorator and uses it to create
retry_safe_popen. Beaker job submission is retried, if stderr stream
contains any of the specificied strings.

See ticket 1127.

Signed-off-by: Jakub Racek <jracek@redhat.com>