### PR TITLE
use cki-lib datadefinition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2017-2019 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2017-2020 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017-2020 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2017-2020 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-
+"""SKT entry point and argument parsing."""
 import argparse
 import atexit
 import itertools

--- a/skt/misc.py
+++ b/skt/misc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2017-2020 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 Red Hat, Inc. All rights reserved. This copyrighted
+# Copyright (c) 2017-2020 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.

--- a/tests/assets/actual_rc.cfg
+++ b/tests/assets/actual_rc.cfg
@@ -1,0 +1,27 @@
+[state]
+workdir = /builds/cki-project/cki-pipeline/workdir
+git_url = git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git
+stage_merge = pass
+make_target = targz-pkg
+commit_message_title = Linux 5.4.11-rc1
+tag = -ed7e2ec
+kernel_type = upstream
+test_hash = ed7e2ecd1b93e8f35aa93d1bd185bf9a4ad1e1dd
+kernel_arch = x86_64
+stage_build = pass
+kernel_version = 5.4.11-rc1-ed7e2ec.cki
+make_opts = -j30 INSTALL_MOD_STRIP=1 targz-pkg
+build_job_url = https://xci32.lab.eng.rdu2.redhat.com/cki-project/cki-pipeline/-/jobs/553679
+tarball_file = kernel-stable-x86_64-ed7e2ecd1b93e8f35aa93d1bd185bf9a4ad1e1dd.tar.gz
+config_file = kernel-stable-x86_64-ed7e2ecd1b93e8f35aa93d1bd185bf9a4ad1e1dd.config
+kernel_package_url = https://artifacts.cki-project.org/pipelines/377632/kernel-stable-x86_64-ed7e2ecd1b93e8f35aa93d1bd185bf9a4ad1e1dd.tar.gz
+kernel_config_url = https://artifacts.cki-project.org/pipelines/377632/kernel-stable-x86_64-ed7e2ecd1b93e8f35aa93d1bd185bf9a4ad1e1dd.config
+debug_kernel = no
+stage_setup = pass
+retcode = 0
+
+
+[runner]
+type = beaker
+jobtemplate = beaker.xml
+blacklist = beaker-blacklist.txt


### PR DESCRIPTION
SKT has had issue with its separation of config file and output for a
while. Because it's function is now limited to watching Beaker Jobs,
it's not critical. However, it is a nice example of how the data
definition could be defined and shared.

Signed-off-by: Jakub Racek <jracek@redhat.com>