### PR TITLE
add retries for bkr job-results call

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -221,7 +221,10 @@ class BeakerRunner:
         """
         args = ["bkr", "job-results", "--prettyxml", taskspec]
 
-        stdout, _, _ = safe_popen(args, stdout=subprocess.PIPE)
+        err_strings = ["ProtocolError", "503 Service Unavailable"]
+        stdout, _, _ = retry_safe_popen(err_strings, args,
+                                        stderr=subprocess.PIPE,
+                                        stdout=subprocess.PIPE)
 
         # Write the Beaker results locally so they could be stored as an
         # artifact.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -302,7 +302,8 @@ class TestRunner(unittest.TestCase):
         self.myrunner._BeakerRunner__add_to_watchlist(j_jobid)
         mock_popen.assert_called_once_with(
             ["bkr", "job-results", "--prettyxml", j_jobid],
-            stdout=subprocess.PIPE
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
         )
 
         # test that whiteboard was parsed OK


### PR DESCRIPTION
As seen in brew-pipeline job 564443, the bkr utility can get a protocol error.
We add the use of retry_safe_popen() wrapper and 2 error strings to
catch and retry on.
This should help mitigate brief transient infra-failures, help to
finish the pipeline run and avoid re-runs.

Signed-off-by: Jakub Racek <jracek@redhat.com>