### PR TITLE
don't log traceback of signal_handler

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -750,8 +750,12 @@ class BeakerRunner:
                 # not waiting -> change retcode to success
                 self.retcode = SKT_SUCCESS
 
-        except (Exception, BaseException):
-            exc = sys.exc_info()
-            logging.error('\n'.join(traceback.format_exception(*exc)))
+        except (Exception, BaseException) as e:
+            if isinstance(e, SystemExit):
+                sys.stderr.write('SystemExit exception caught\n')
+                raise
+            else:
+                exc = sys.exc_info()
+                logging.error('\n'.join(traceback.format_exception(*exc)))
 
         return self.retcode


### PR DESCRIPTION
When we do our signal_handler() to do cleanup and sys.exit(SKT_ERROR) on
timeout, we end-up catching the SystemExit exception and logging
the traceback. Also, we don't really return SKT_ERROR, that's likely set
by pipeline.
This has no consequences for testing itself, but scripts
that look at output would think this traceback is an indication of far,
which isn't far from the truth. So let's fix this cosmetic bug, log this
and reraise the exception.

Signed-off-by: Jakub Racek <jracek@redhat.com>