### PR TITLE
Don't remove hostname settings in retries

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -377,10 +377,11 @@ class BeakerRunner:
 
         for recipe in tmp.findall('recipe'):
             hreq = recipe.find("hostRequires")
-            hostname = hreq.find('hostname')
-            if hostname is not None:
-                hreq.remove(hostname)
             if samehost:
+                hostname = hreq.find('hostname')
+                if hostname is not None:
+                    hreq.remove(hostname)
+
                 value = recipe.attrib.get("system")
                 hostname = fromstring(f'<hostname op="=" value="{value}"/>')
                 hreq.append(hostname)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -359,8 +359,10 @@ class TestRunner(unittest.TestCase):
 
         result = self.myrunner._BeakerRunner__recipe_set_to_job(xml_parsed)
 
-        # check that <hostname op="!=" value="hst1"/> was removed
-        self.assertEqual(result.findall('.//hostname'), [])
+        # check that <hostname op="!=" value="hst1"/> wasn't removed
+        self.assertEqual(len(result.findall('.//hostname')), 1)
+        self.assertEqual(tostring(result.find('.//hostname')).decode(),
+                         '<hostname op="!=" value="hst1" />')
 
     @mock.patch('skt.runner.BeakerRunner._BeakerRunner__jobsubmit')
     def test_run(self, mock_jobsubmit):


### PR DESCRIPTION
kpet-db contains a lot of hostname blacklisting to avoid running on
unsupported machines. We need to keep them for retries, otherwise the
recipes could end up running on those machines and just abort.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>